### PR TITLE
Fix #1433: Add MI.terminate-server to editor/title/run toolbar menu

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,0 +1,1152 @@
+{
+  "name": "micro-integrator",
+  "displayName": "WSO2 Integrator: MI",
+  "description": "An extension which gives a development environment for designing, developing, debugging, and testing integration solutions.",
+  "icon": "resources/images/wso2-micro-integrator-image.png",
+  "version": "3.1.526032514",
+  "publisher": "wso2",
+  "engines": {
+    "vscode": "^1.100.0"
+  },
+  "categories": [
+    "Other"
+  ],
+  "activationEvents": [
+    "onLanguage:SynapseXml",
+    "workspaceContains:.project",
+    "workspaceContains:pom.xml",
+    "onDebugResolve:mi",
+    "onDebugDynamicConfigurations:mi",
+    "onUri"
+  ],
+  "extensionDependencies": [
+    "wso2.wso2-platform"
+  ],
+  "main": "./dist/extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "SynapseXml",
+        "extensions": [
+          ".xml",
+          ".dbs"
+        ],
+        "configuration": "./language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "SynapseXml",
+        "scopeName": "synapse.xml",
+        "path": "./syntaxes/xml.tmLanguage.json"
+      }
+    ],
+    "breakpoints": [
+      {
+        "language": "SynapseXml"
+      }
+    ],
+    "taskDefinitions": [
+      {
+        "type": "mi-build"
+      },
+      {
+        "type": "mi-run"
+      },
+      {
+        "type": "mi-stop"
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "mi",
+        "label": "MI: Run and Debug",
+        "runtime": "node",
+        "languages": [
+          "SynapseXml"
+        ],
+        "configurationAttributes": {
+          "launch": {
+            "properties": {
+              "env": {
+                "type": "object",
+                "description": "Environment variables to set for the MI server",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
+              "vmArgs": {
+                "type": "array",
+                "description": "Arguments to pass to the MI server",
+                "items": {
+                  "type": "string"
+                },
+                "default": []
+              },
+              "properties": {
+                "type": "object",
+                "description": "Debug properties for remote debugging",
+                "additionalProperties": {
+                  "type": [
+                    "string",
+                    "number"
+                  ]
+                },
+                "default": {}
+              }
+            }
+          }
+        },
+        "initialConfigurations": [
+          {
+            "type": "mi",
+            "name": "MI: Local Server Run and Debug",
+            "request": "launch",
+            "internalConsoleOptions": "openOnSessionStart",
+            "vmArgs": [],
+            "properties": {
+              "type": "local"
+            }
+          },
+          {
+            "type": "mi",
+            "name": "MI: Remote Server Run and Debug",
+            "request": "launch",
+            "internalConsoleOptions": "openOnSessionStart",
+            "vmArgs": [],
+            "properties": {
+              "type": "remote",
+              "commandPort": 9005,
+              "eventPort": 9006,
+              "serverHost": "localhost",
+              "serverPort": 8290,
+              "serverReadinessPort": 9201,
+              "managementPort": 9164,
+              "managementUsername": "admin",
+              "managementPassword": "admin",
+              "connectionTimeoutInSecs": 10
+            }
+          }
+        ]
+      }
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "WSO2 Integrator: MI",
+      "properties": {
+        "MI.debugger.commandPort": {
+          "type": "number",
+          "default": 9005,
+          "description": "Command port for the debugger to communicate with the MI server"
+        },
+        "MI.debugger.eventPort": {
+          "type": "number",
+          "default": 9006,
+          "description": "Event port for the MI server to communicate with the debugger"
+        },
+        "MI.serverPort": {
+          "type": "number",
+          "default": 8290,
+          "description": "Port to check the readiness of the MI server"
+        },
+        "MI.SERVER_PATH": {
+          "type": "string",
+          "default": "",
+          "description": "Location to store MI archives, considering the user's home directory",
+          "scope": "resource"
+        },
+        "MI.JAVA_HOME": {
+          "type": "string",
+          "default": "",
+          "description": "Java Home path",
+          "scope": "resource"
+        },
+        "MI.LEGACY_EXPRESSION_ENABLED": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable legacy expression support",
+          "scope": "resource"
+        },
+        "MI.REMOTE_DEPLOYMENT_ENABLED": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable remote server deployment support",
+          "scope": "resource"
+        },
+        "MI.useLocalMaven": {
+          "type": "boolean",
+          "default": false,
+          "description": "Use local Maven within the extension",
+          "scope": "resource"
+        },
+        "MI.Scope": {
+          "type": "string",
+          "default": "",
+          "description": "Devant project scope",
+          "scope": "resource"
+        },
+        "MI.suppressServerUpdateNotification": {
+          "type": "boolean",
+          "default": false,
+          "description": "Don't show server update notification",
+          "scope": "resource"
+        },
+        "MI.autoUpdateCarPlugin": {
+          "type": "boolean",
+          "default": true,
+          "description": "Update car plugin version automatically"
+        },
+        "MI.useDefaultMavenForMigration": {
+          "type": "boolean",
+          "default": true,
+          "description": "Use built-in default Maven version for migration"
+        },
+        "MI.serverTimeoutInSecs": {
+          "type": "number",
+          "default": 120,
+          "minimum": 30,
+          "description": "Maximum wait time for server startup in seconds"
+        },
+        "MI.logging.loggingLevel": {
+          "type": "string",
+          "enum": [
+            "off",
+            "error",
+            "warn",
+            "info",
+            "debug"
+          ],
+          "default": "error",
+          "description": "The verbosity of logging. The Order is off < error < warn < info < debug.",
+          "scope": "window"
+        }
+      }
+    },
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "micro-integrator",
+          "title": "WSO2 Integrator: MI",
+          "icon": "assets/icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "micro-integrator": [
+        {
+          "id": "MI.project-explorer",
+          "name": "Project Explorer",
+          "when": "!wso2-integrator.explorer.visible"
+        }
+      ],
+      "test": [
+        {
+          "id": "MI.mock-services",
+          "name": "Mock Services",
+          "when": "MI.status == 'projectLoaded'"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "MI.project-explorer",
+        "contents": "Loading...",
+        "when": "!wso2-integrator.explorer.visible && (MI.status != 'unknownProject' && MI.status != 'projectLoaded' && MI.status != 'disabled' && MI.status != 'notSetUp')"
+      },
+      {
+        "view": "MI.project-explorer",
+        "contents": "Welcome to WSO2 Integrator: MI. You can open a folder containing a MI project or create a new project.\n[Create New Project](command:MI.project-explorer.create-project)\n[Open MI Project](command:MI.openProject)\n[Import from CApp](command:MI.importProjectFromCapp)\nTo learn more about how to use WSO2 Integrator: MI in VS Code, [read our docs](https://mi.docs.wso2.com/en/4.3.0/develop/mi-for-vscode/mi-for-vscode-overview/).",
+        "when": "!wso2-integrator.explorer.visible && MI.status == 'unknownProject'"
+      },
+      {
+        "view": "MI.project-explorer",
+        "contents": "Some errors occurred while activating the extension. Please check the output channel for more information.",
+        "when": "!wso2-integrator.explorer.visible && MI.status == 'disabled'"
+      },
+      {
+        "view": "MI.project-explorer",
+        "contents": "WSO2 Integrator: MI is not set up. Please set up the MI server and Java home to continue.",
+        "when": "!wso2-integrator.explorer.visible && MI.status == 'notSetUp'"
+      },
+      {
+        "view": "wso2-integrator.explorer",
+        "contents": "Some errors occurred while activating the extension. Please check the output channel for more information.",
+        "when": "wso2-integrator.explorer.visible != '' && MI.status == 'disabled'"
+      },
+      {
+        "view": "wso2-integrator.explorer",
+        "contents": "WSO2 Integrator: MI is not set up. Please set up the MI server and Java home to continue.",
+        "when": "wso2-integrator.explorer.visible != '' && MI.status == 'notSetUp'"
+      },
+      {
+        "view": "testing",
+        "contents": "[Add Unit Test](command:MI.test.add.suite)",
+        "when": "MI.status == 'projectLoaded'"
+      }
+    ],
+    "commands": [
+      {
+        "command": "MI.openProject",
+        "title": "Open Project",
+        "category": "MI"
+      },
+      {
+        "command": "MI.importProjectFromZip",
+        "title": "Import project from ZIP archive",
+        "category": "MI"
+      },
+      {
+        "command": "MI.exportProjectAsZip",
+        "title": "Export project as ZIP archive",
+        "category": "MI"
+      },
+      {
+        "command": "MI.importProjectFromCapp",
+        "title": "Import from CApp",
+        "category": "MI"
+      },
+      {
+        "command": "MI.openWelcome",
+        "title": "Open MI Welcome",
+        "category": "MI"
+      },
+      {
+        "command": "MI.showOverview",
+        "title": "Show Overview",
+        "category": "MI"
+      },
+      {
+        "command": "MI.openAiPanel",
+        "title": "Open AI Panel",
+        "category": "MI",
+        "icon": "$(wand)"
+      },
+      {
+        "command": "MI.configureDefaultModelProvider",
+        "title": "Configure Default WSO2 Model Provider",
+        "category": "MI"
+      },
+      {
+        "command": "MI.Open-runtime-service-view",
+        "title": "Open Runtime Services Panel",
+        "category": "MI",
+        "icon": "$(server)",
+        "when": "MI.isRunning== 'true'"
+      },
+      {
+        "command": "MI.project-explorer.add.artifact",
+        "title": "Add Artifact",
+        "icon": "$(add)",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.refresh",
+        "title": "Refresh Project Explorer",
+        "icon": "$(refresh)",
+        "group": "navigation"
+      },
+      {
+        "command": "MI.project-explorer.add-api",
+        "title": "Add API",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-resource",
+        "title": "Add Resource",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.create-project",
+        "title": "Create New Project",
+        "category": "MI"
+      },
+      {
+        "command": "MI.openWelcome",
+        "title": "Create New Project",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.open-project-overview",
+        "title": "Open Project Overview",
+        "icon": "$(list-unordered)",
+        "when": "false"
+      },
+      {
+        "command": "MI.project-explorer.open-service-designer",
+        "title": "Open Service Designer",
+        "icon": "$(mi-design-view)",
+        "when": "false"
+      },
+      {
+        "command": "MI.show.graphical-view",
+        "title": "Open Graphical View",
+        "icon": "$(mi-design-view)"
+      },
+      {
+        "command": "MI.project-explorer.add-endpoint",
+        "title": "Add Endpoint",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-sequence",
+        "title": "Add Sequence",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-inbound-endpoint",
+        "title": "Add Inbound Endpoint",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-message-processor",
+        "title": "Add Message Processor",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-proxy-service",
+        "title": "Add Proxy Service",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-template",
+        "title": "Add Template",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-local-entry",
+        "title": "Add Local Entry",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-connection",
+        "title": "Add Connection",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-registry-resource",
+        "title": "Add Registry Resource",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-class-mediator",
+        "title": "Add Class Mediator",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-ballerina-module",
+        "title": "Add Ballerina Module",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-task",
+        "title": "Add Scheduled Task",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-message-store",
+        "title": "Add Message Store",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-data-source",
+        "title": "Add Data Source",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.add-data-service",
+        "title": "Add Data Service",
+        "icon": "$(add)",
+        "group": "navigation",
+        "category": "MI"
+      },
+      {
+        "command": "MI.project-explorer.open-dss-service-designer",
+        "title": "Open Service Designer",
+        "icon": "$(mi-design-view)",
+        "when": "false"
+      },
+      {
+        "command": "MI.project-explorer.delete",
+        "title": "Delete",
+        "icon": "$(trash)"
+      },
+      {
+        "command": "MI.manage-registry-property",
+        "title": "Manage Properties",
+        "icon": "$(add)"
+      },
+      {
+        "command": "MI.project-explorer.markAsDefaultSequence",
+        "title": "Set as Automation Sequence",
+        "icon": "$(star)"
+      },
+      {
+        "command": "MI.project-explorer.unmarkAsDefaultSequence",
+        "title": "Unset as Automation Sequence",
+        "icon": "$(star-full)"
+      },
+      {
+        "command": "project-explorer.view",
+        "title": "View"
+      },
+      {
+        "command": "MI.show.source",
+        "title": "Show Source",
+        "icon": "$(code)",
+        "category": "MI"
+      },
+      {
+        "command": "MI.change.server",
+        "title": "Add MI server",
+        "category": "MI"
+      },
+      {
+        "command": "MI.change.java",
+        "title": "Set Java Home",
+        "category": "MI"
+      },
+      {
+        "command": "MI.build-project",
+        "title": "Build",
+        "category": "MI"
+      },
+      {
+        "command": "MI.build-and-run",
+        "title": "Build and Run",
+        "icon": "$(play)",
+        "category": "MI"
+      },
+      {
+        "command": "MI.terminate-server",
+        "title": "Stop MI Server Session",
+        "category": "MI",
+        "icon": "$(debug-stop)"
+      },
+      {
+        "command": "MI.build-bal-module",
+        "title": "Build Ballerina Module",
+        "icon": "$(mi-build-package)",
+        "category": "MI"
+      },
+      {
+        "command": "MI.test.add.suite",
+        "title": "Add unit test",
+        "icon": "$(add)",
+        "category": "MI"
+      },
+      {
+        "command": "MI.test.edit.suite",
+        "title": "Edit test suite",
+        "icon": "$(mi-design-view)",
+        "category": "MI"
+      },
+      {
+        "command": "MI.test.add.case",
+        "title": "Add test case",
+        "icon": "$(add)",
+        "category": "MI"
+      },
+      {
+        "command": "MI.test.edit.case",
+        "title": "Edit test case",
+        "icon": "$(mi-design-view)",
+        "category": "MI"
+      },
+      {
+        "command": "MI.test.add.mock-service",
+        "title": "Add mock service",
+        "icon": "$(add)",
+        "category": "MI"
+      },
+      {
+        "command": "MI.test.edit.mock-service",
+        "title": "Edit mock service",
+        "icon": "$(mi-design-view)",
+        "category": "MI"
+      },
+      {
+        "command": "MI.test.refresh.mock-services",
+        "title": "Refresh",
+        "icon": "$(refresh)",
+        "category": "MI"
+      },
+      {
+        "command": "MI.test.delete.mock-service",
+        "title": "Delete Mock Service",
+        "icon": "$(trash)",
+        "category": "MI"
+      },
+      {
+        "command": "MI.test.delete.case",
+        "title": "Delete Test Case",
+        "icon": "$(trash)",
+        "category": "MI"
+      },
+      {
+        "command": "MI.test.delete.suite",
+        "title": "Delete Test Suite",
+        "icon": "$(trash)",
+        "category": "MI"
+      }
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "MI.project-explorer.add-api",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-resource",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-endpoint",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-sequence",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-inbound-endpoint",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-local-entry",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-connection",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-registry-resource",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-class-mediator",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-ballerina-module",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-message-processor",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-proxy-service",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-task",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-message-store",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-data-source",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-template",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.add-data-service",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.open-dss-service-designer",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.open-service-designer",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.delete",
+          "when": "false"
+        },
+        {
+          "command": "MI.manage-registry-property",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.markAsDefaultSequence",
+          "when": "false"
+        },
+        {
+          "command": "MI.project-explorer.unmarkAsDefaultSequence",
+          "when": "false"
+        },
+        {
+          "command": "MI.show.source",
+          "when": "false"
+        },
+        {
+          "command": "MI.show.graphical-view",
+          "when": "false"
+        },
+        {
+          "command": "MI.build-and-run",
+          "when": "false"
+        },
+        {
+          "command": "MI.build-bal-module",
+          "when": "false"
+        },
+        {
+          "command": "MI.test.add.suite",
+          "when": "false"
+        },
+        {
+          "command": "MI.test.edit.suite",
+          "when": "false"
+        },
+        {
+          "command": "MI.test.add.case",
+          "when": "false"
+        },
+        {
+          "command": "MI.test.edit.case",
+          "when": "false"
+        },
+        {
+          "command": "MI.test.add.mock-service",
+          "when": "false"
+        },
+        {
+          "command": "MI.test.edit.mock-service",
+          "when": "false"
+        },
+        {
+          "command": "MI.test.refresh.mock-services",
+          "when": "false"
+        },
+        {
+          "command": "MI.test.delete.mock-service",
+          "when": "false"
+        },
+        {
+          "command": "MI.test.delete.case",
+          "when": "false"
+        },
+        {
+          "command": "MI.test.delete.suite",
+          "when": "false"
+        },
+        {
+          "command": "MI.importProjectFromCapp",
+          "when": "false"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "MI.project-explorer.refresh",
+          "when": "view == MI.project-explorer && projectOpened",
+          "group": "navigation"
+        },
+        {
+          "command": "MI.openWelcome",
+          "when": "view == MI.project-explorer && projectOpened",
+          "group": "navigation"
+        },
+        {
+          "command": "MI.test.add.suite",
+          "when": "view == workbench.view.testing",
+          "group": "navigation"
+        },
+        {
+          "command": "MI.test.refresh.mock-services",
+          "when": "view == MI.mock-services && projectOpened",
+          "group": "navigation"
+        }
+      ],
+      "editor/title/run": [
+        {
+          "command": "MI.build-and-run",
+          "group": "navigation@1",
+          "when": "MI.status == 'projectLoaded' && (isVisualizerActive || resourceLangId == SynapseXml) && (MI.isRunning !== 'true') && !editorTextFocus",
+          "title": "Build and Run Project"
+        },
+        {
+          "command": "MI.terminate-server",
+          "icon": "$(debug-stop)",
+          "group": "navigation@1",
+          "when": "MI.status == 'projectLoaded' && (isVisualizerActive || resourceLangId == SynapseXml) && MI.isRunning == 'true' && !editorTextFocus"
+        }
+      ],
+      "editor/title": [
+        {
+          "command": "MI.openAiPanel",
+          "group": "navigation@1",
+          "when": "MI.projectType == 'miProject' && (isVisualizerActive || resourceLangId == SynapseXml) && !editorTextFocus",
+          "title": "Open AI Panel"
+        },
+        {
+          "command": "MI.Open-runtime-service-view",
+          "group": "navigation@1",
+          "when": "MI.projectType == 'miProject' && (isVisualizerActive || resourceLangId == SynapseXml) && MI.isRunning== 'true'",
+          "title": "Open Runtime Services Panel"
+        },
+        {
+          "command": "MI.show.graphical-view",
+          "when": "MI.status == 'projectLoaded' && resourceLangId == SynapseXml",
+          "group": "navigation@3",
+          "title": "Show Graphical View"
+        },
+        {
+          "command": "MI.show.source",
+          "when": "isVisualizerActive && showGoToSource",
+          "group": "navigation@3",
+          "title": "Show Source"
+        },
+        {
+          "command": "MI.build-bal-module",
+          "group": "navigation",
+          "when": "resourceExtname == .bal",
+          "title": "Build Ballerina Module"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "MI.project-explorer.add.artifact",
+          "when": "viewItem == project",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.open-project-overview",
+          "when": "viewItem == project",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-api",
+          "when": "view == MI.project-explorer && viewItem == apis",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-resource",
+          "when": "view == MI.project-explorer && viewItem == resources",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.open-service-designer",
+          "when": "viewItem == api",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-endpoint",
+          "when": "view == MI.project-explorer && viewItem == endpoints",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-sequence",
+          "when": "view == MI.project-explorer && viewItem == sequences",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-inbound-endpoint",
+          "when": "view == MI.project-explorer && viewItem == inboundEndpoints",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-local-entry",
+          "when": "view == MI.project-explorer && viewItem == localEntries",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-connection",
+          "when": "view == MI.project-explorer && viewItem == connections",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-registry-resource",
+          "when": "view == MI.project-explorer && viewItem == registry",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-class-mediator",
+          "when": "view == MI.project-explorer && viewItem == class-mediators",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-ballerina-module",
+          "when": "view == MI.project-explorer && viewItem == ballerina-modules",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-message-processor",
+          "when": "view == MI.project-explorer && viewItem == messageProcessors",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-proxy-service",
+          "when": "view == MI.project-explorer && viewItem == proxyServices",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-task",
+          "when": "view == MI.project-explorer && viewItem == tasks",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-message-store",
+          "when": "view == MI.project-explorer && viewItem == messageStores",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-data-source",
+          "when": "view == MI.project-explorer && viewItem == dataSources",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-template",
+          "when": "view == MI.project-explorer && viewItem == templates",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.add-data-service",
+          "when": "view == MI.project-explorer && viewItem == dataServices",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.delete",
+          "when": "view == MI.project-explorer && viewItem == api || viewItem == resource || viewItem == endpoint || viewItem == sequence || viewItem == proxy-service || viewItem == inboundEndpoint || viewItem == messageStore || viewItem == message-processor || viewItem == task || viewItem == localEntry || viewItem == template  || viewItem == dataSource || viewItem == data-service || viewItem == data-mapper || viewItem == connection || viewItem == registry-with-metadata || viewItem == registry-without-metadata || viewItem == class-mediator || viewItem == ballerina-module || viewItem == idp-schema",
+          "key": "delete"
+        },
+        {
+          "command": "MI.manage-registry-property",
+          "when": "view == MI.project-explorer && (viewItem == resource || viewItem == registry-with-metadata || viewItem == registry-without-metadata)",
+          "key": "add-registry-property"
+        },
+        {
+          "command": "MI.project-explorer.markAsDefaultSequence",
+          "when": "view == MI.project-explorer && viewItem == sequence",
+          "group": "inline"
+        },
+        {
+          "command": "MI.project-explorer.unmarkAsDefaultSequence",
+          "when": "view == MI.project-explorer && viewItem == sequence-main",
+          "group": "inline"
+        },
+        {
+          "command": "MI.test.add.mock-service",
+          "group": "inline",
+          "when": "view == MI.mock-services && viewItem == workspace"
+        },
+        {
+          "command": "MI.test.edit.mock-service",
+          "group": "inline",
+          "when": "view == MI.mock-services && viewItem == mockService"
+        },
+        {
+          "command": "MI.test.delete.mock-service",
+          "group": "inline",
+          "when": "view == MI.mock-services"
+        }
+      ],
+      "testing/item/context": [
+        {
+          "command": "MI.test.add.suite",
+          "group": "inline",
+          "when": "testId in test.dirs"
+        },
+        {
+          "command": "MI.test.edit.suite",
+          "group": "inline",
+          "when": "testId in test.suites"
+        },
+        {
+          "command": "MI.test.add.case",
+          "group": "inline",
+          "when": "MI.status == 'projectLoaded' && testId in test.suites"
+        },
+        {
+          "command": "MI.test.edit.case",
+          "group": "inline",
+          "when": "testId in test.cases"
+        },
+        {
+          "command": "MI.test.delete.case",
+          "group": "inline",
+          "when": "testId in test.cases"
+        },
+        {
+          "command": "MI.test.delete.suite",
+          "group": "inline",
+          "when": "testId in test.suites"
+        }
+      ],
+      "testing/message/context": []
+    },
+    "icons": {
+      "mi-design-view": {
+        "description": "design-view",
+        "default": {
+          "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
+          "fontCharacter": "\\f1bb"
+        }
+      },
+      "mi-build-package": {
+        "description": "build-package",
+        "default": {
+          "fontPath": "./resources/font-wso2-vscode/dist/wso2-vscode.woff",
+          "fontCharacter": "\\f193"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "clean": "rimraf ./dist",
+    "compile": "tsc -p .",
+    "watch": "tsc -p . -w",
+    "package": "node ../../common-libs/scripts/package-vsix.js",
+    "download-ls": "node ./scripts/download-ls.js",
+    "build": "pnpm clean && pnpm run download-ls && pnpm run copyJSLibs && pnpm run copyLSLibs && pnpm run copyFonts && pnpm run copyDMUtils && pnpm run renameDMUtils && webpack --mode production --devtool hidden-source-map && pnpm run package && pnpm run postbuild",
+    "compile-tests": "pnpm run compile",
+    "watch-tests": "pnpm run watch",
+    "pretest": "pnpm run compile-tests && pnpm run compile && pnpm run lint",
+    "lint": "eslint src --ext ts",
+    "test": "pnpm run pretest && node ./out/test/runTest.js",
+    "e2e-test": "pnpm run compile-tests && pnpm exec playwright test",
+    "copyFonts": "copyfiles -f ./node_modules/@wso2/font-wso2-vscode/dist/* ./resources/font-wso2-vscode/dist/",
+    "copyJSLibs": "copyfiles -f ../mi-visualizer/build/*.js resources/jslibs",
+    "copyLSLibs": "copyfiles -f language-server/org.eclipse.lemminx/target/*.jar ls",
+    "copyDMUtils": "copyfiles -f ./node_modules/@wso2/mi-data-mapper-utils/src/* ./resources/data-mapper-utils/",
+    "renameDMUtils": "node -e \"require('fs').rename('./resources/data-mapper-utils/dm-utils.ts', './resources/data-mapper-utils/dm-utils.ts.lib', function(err) { if (err) console.log(err); else console.log('DMUtils successfully renamed!') })\"",
+    "copyVSIX": "copyfiles *.vsix ./vsix",
+    "copyVSIXToRoot": "copyfiles -f ./vsix/* ../../..",
+    "postbuild": "pnpm run copyVSIX"
+  },
+  "devDependencies": {
+    "@ai-sdk/devtools": "0.0.6",
+    "@playwright/test": "1.55.1",
+    "@types/mocha": "10.0.1",
+    "@types/node": "22.15.21",
+    "@types/vscode": "1.100.0",
+    "@typescript-eslint/eslint-plugin": "8.32.1",
+    "@typescript-eslint/parser": "8.32.1",
+    "@vscode/test-electron": "2.5.2",
+    "@wso2/mi-data-mapper-utils": "workspace:*",
+    "@wso2/mi-diagram": "workspace:*",
+    "@wso2/mi-rpc-client": "workspace:*",
+    "@wso2/mi-visualizer": "workspace:*",
+    "@wso2/wso2-platform-core": "workspace:*",
+    "await-notify": "1.0.1",
+    "eslint": "9.27.0",
+    "glob": "11.1.0",
+    "mocha": "11.4.0",
+    "playwright-core": "1.55.1",
+    "rimraf": "6.0.1",
+    "ts-loader": "9.5.2",
+    "ts-morph": "26.0.0",
+    "typescript": "5.8.3",
+    "webpack": "5.104.1",
+    "webpack-cli": "4.10.0",
+    "yaml": "2.8.0"
+  },
+  "dependencies": {
+    "@ai-sdk/amazon-bedrock": "4.0.4",
+    "@ai-sdk/anthropic": "3.0.46",
+    "@anthropic-ai/tokenizer": "0.0.4",
+    "@apidevtools/json-schema-ref-parser": "12.0.2",
+    "@babel/core": "7.27.1",
+    "@babel/plugin-transform-typescript": "7.27.1",
+    "@iarna/toml": "2.2.5",
+    "@langfuse/otel": "4.5.1",
+    "@opentelemetry/sdk-node": "0.210.0",
+    "ai": "6.0.94",
+    "@types/fs-extra": "11.0.4",
+    "@types/handlebars": "4.1.0",
+    "@types/json-schema": "7.0.15",
+    "@types/lodash": "4.17.17",
+    "@types/mustache": "4.2.6",
+    "@types/tmp": "0.2.6",
+    "@types/xml2js": "0.4.12",
+    "@vscode/vsce": "3.7.1",
+    "@wso2/font-wso2-vscode": "workspace:*",
+    "@wso2/mi-core": "workspace:*",
+    "@wso2/mi-diagram": "workspace:*",
+    "@wso2/mi-rpc-client": "workspace:*",
+    "@wso2/mi-syntax-tree": "workspace:*",
+    "@wso2/playwright-vscode-tester": "workspace:*",
+    "adm-zip": "0.5.16",
+    "axios": "1.13.5",
+    "canonicalize": "2.1.0",
+    "copyfiles": "2.4.1",
+    "cors-anywhere": "0.4.4",
+    "dotenv": "16.5.0",
+    "fast-xml-parser": "5.2.3",
+    "find-process": "1.4.10",
+    "fs-extra": "11.3.0",
+    "glob": "11.1.0",
+    "handlebars": "4.7.8",
+    "json-schema": "0.4.0",
+    "json-schema-to-ts": "3.1.1",
+    "jsonix": "3.0.0",
+    "jwt-decode": "4.0.0",
+    "langfuse": "3.38.6",
+    "lodash": "4.17.23",
+    "mustache": "4.2.0",
+    "node-fetch": "3.3.2",
+    "node-loader": "2.1.0",
+    "pdf-lib": "1.17.1",
+    "portfinder": "1.0.37",
+    "recast": "0.23.11",
+    "tmp": "0.2.4",
+    "to-json-schema": "0.2.5",
+    "tree-kill": "1.2.2",
+    "unzipper": "0.12.3",
+    "unique-names-generator": "4.7.1",
+    "upath": "2.0.1",
+    "uuid": "11.1.0",
+    "vscode-debugadapter": "1.51.0",
+    "vscode-debugprotocol": "1.51.0",
+    "vscode-extension-tester": "8.14.1",
+    "vscode-languageclient": "9.0.1",
+    "vscode-languageserver-protocol": "3.17.5",
+    "vscode-messenger": "0.5.1",
+    "vscode-messenger-common": "0.5.1",
+    "xml2js": "0.6.2",
+    "xstate": "4.38.3",
+    "zod": "4.1.11"
+  }
+}


### PR DESCRIPTION
## Purpose
Fixes #1433 — After clicking **Build and Run**, the play button (▷) disappears but no stop button ever appears, leaving users unable to stop the running MI server from the VS Code UI.

## Goals
Add the missing `MI.terminate-server` entry to the `editor/title/run` menu contribution so that a stop button (■) appears in the editor title toolbar whenever `MI.isRunning == 'true'`.

## Approach

### Root Cause
The `MI.terminate-server` command was registered in `contributes.commands` but had **no entry in any menu**. The play button correctly hides when `MI.isRunning === 'true'` (its `when` clause becomes false), but no stop button was ever registered to appear in its place.

### Fix (in `extension/package.json`)

**1. Added `MI.terminate-server` to `contributes.menus["editor/title/run"]`:**
```json
{
  "command": "MI.terminate-server",
  "icon": "$(debug-stop)",
  "group": "navigation@1",
  "when": "MI.status == 'projectLoaded' && (isVisualizerActive || resourceLangId == SynapseXml) && MI.isRunning == 'true' && !editorTextFocus"
}
```
This `when` clause is the exact complement of the play button's `MI.isRunning !== 'true'`, ensuring the buttons swap correctly as the server starts/stops.

**2. Added `icon: $(debug-stop)` to the `MI.terminate-server` command definition** so it renders correctly as an icon-only toolbar button.

### Before / After

| State | Before fix | After fix |
|-------|-----------|-----------|
| MI not running | ▷ play visible | ▷ play visible |
| MI running | *(no button)* | ■ stop visible |

## User stories
- As an MI developer, I want to be able to stop a running MI server session directly from the VS Code toolbar without having to kill the Java process manually.

## Release note
Fixed an issue where the Stop MI Server button was not appearing in the editor title toolbar after Build and Run was triggered (issue #1433).

## Automation tests
- Unit tests: Verified via static `package.json` analysis confirming both `editor/title/run` entries are present with complementary `when` clauses.
- Integration tests: Verified via Playwright runtime test — stop button (`codicon-debug-stop`) appears within 5 seconds after clicking Build and Run.

## Security checks
- Followed secure coding standards: yes
- Ran FindSecurityBugs plugin: N/A (JSON configuration change only)
- No keys, passwords, tokens, or secrets committed: yes

## Test environment
- code-server 4.114.0 / VS Code 1.114.0
- MI Runtime: wso2mi-4.6.0-SNAPSHOT
- Java: Eclipse Adoptium JDK 21.0.5
- OS: macOS Darwin 24.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * WSO2 Integrator: MI extension for VS Code now available
  * SynapseXml language support with syntax highlighting and debugging
  * Integrated project explorer with creation and management commands
  * Build, run, and stop server tasks
  * Local and remote debugging configurations
  * Mock services and test suite operations
  * Configurable server and logging settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->