### PR TITLE
Fix false-positive UndefinedVariable warning for foreach counter-variable

### DIFF
--- a/packages/mi-language-server/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipant.java
+++ b/packages/mi-language-server/org.eclipse.lemminx/src/main/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipant.java
@@ -1201,12 +1201,23 @@ public class SynapseDiagnosticsParticipant implements IDiagnosticsParticipant {
         } else if ("foreach".equals(name) || "iterate".equals(name)) {
             // foreach/iterate implicitly define a loop counter variable
             // and the collection item is accessible in the flow
+            collectVariableFromAttribute(element, "counter-variable", definedVariables);
+            collectVariableFromAttribute(element, "target-variable", definedVariables);
+        } else if ("scatter-gather".equals(name)) {
+            collectVariableFromAttribute(element, "target-variable", definedVariables);
         } else if ("responseVariable".equals(name)) {
             // <responseVariable>varName</responseVariable> in connector operations and AI mediators
             String varName = getElementTextContent(element);
             if (varName != null) {
                 definedVariables.add(varName);
             }
+        }
+    }
+
+    private void collectVariableFromAttribute(DOMElement element, String attributeName, Set<String> definedVariables) {
+        String varName = element.getAttribute(attributeName);
+        if (varName != null && !varName.isEmpty()) {
+            definedVariables.add(varName);
         }
     }
 

--- a/packages/mi-language-server/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipantTest.java
+++ b/packages/mi-language-server/org.eclipse.lemminx/src/test/java/org/eclipse/lemminx/extensions/synapse/SynapseDiagnosticsParticipantTest.java
@@ -468,6 +468,57 @@ public class SynapseDiagnosticsParticipantTest {
         assertTrue(diags.isEmpty(), "responseVariable child element should define the variable");
     }
 
+    @Test
+    public void testForeachCounterVariableDefinesVariable() {
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<foreach collection=\"json-eval($.someList)\" parallel-execution=\"false\" counter-variable=\"idx\">"
+                + "  <sequence>"
+                + "    <variable name=\"currentRow\" type=\"INTEGER\" expression=\"${vars.idx}\"/>"
+                + "  </sequence>"
+                + "</foreach>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UndefinedVariable");
+        assertTrue(diags.isEmpty(), "foreach counter-variable attribute should define the variable");
+    }
+
+    @Test
+    public void testForeachTargetVariableDefinesVariable() {
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<foreach collection=\"json-eval($.someList)\" parallel-execution=\"false\" target-variable=\"aggregatedResult\">"
+                + "  <sequence>"
+                + "    <log><message>processing</message></log>"
+                + "  </sequence>"
+                + "</foreach>"
+                + "<log level=\"custom\"><property name=\"x\" expression=\"${vars.aggregatedResult}\"/></log>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UndefinedVariable");
+        assertTrue(diags.isEmpty(), "foreach target-variable attribute should define the variable");
+    }
+
+    @Test
+    public void testScatterGatherTargetVariableDefinesVariable() {
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<scatter-gather parallel-execution=\"false\" target=\"Variable\" target-variable=\"scatterResult\">"
+                + "</scatter-gather>"
+                + "<log level=\"custom\"><property name=\"x\" expression=\"${vars.scatterResult}\"/></log>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UndefinedVariable");
+        assertTrue(diags.isEmpty(), "scatter-gather target-variable attribute should define the variable");
+    }
+
+    @Test
+    public void testForeachEmptyCounterVariableDoesNotDefine() {
+        String xml = "<sequence xmlns=\"" + SYNAPSE_NS + "\" name=\"test\">"
+                + "<foreach collection=\"json-eval($.someList)\" parallel-execution=\"false\" counter-variable=\"\">"
+                + "  <sequence>"
+                + "    <variable name=\"currentRow\" type=\"INTEGER\" expression=\"${vars.idx}\"/>"
+                + "  </sequence>"
+                + "</foreach>"
+                + "</sequence>";
+        List<Diagnostic> diags = diagnosticsWithCode(diagnose(xml), "UndefinedVariable");
+        assertEquals(1, diags.size(), "empty counter-variable should not define variable");
+    }
+
     // ===== Variable references in element text content (Issue #4) =====
 
     @Test


### PR DESCRIPTION
### Description
Fixes #1518.

This PR addresses a false-positive `UndefinedVariable` warning flagged by the Language Server diagnostics when using the `foreach` mediator with a `counter-variable` or `target-variable` attribute (and similarly on `scatter-gather` mediator with `target-variable`).

The static analyzer's variable definition collector (`collectVariableDefinition` in `SynapseDiagnosticsParticipant.java`) did not account for variables implicitly declared by mediator attributes. I added logic to extract and record:
- `counter-variable` and `target-variable` attributes on `foreach` and `iterate` mediators.
- `target-variable` attribute on `scatter-gather` mediator.

### Testing
Added 4 new test cases in `SynapseDiagnosticsParticipantTest.java`:
- `testForeachCounterVariableDefinesVariable`
- `testForeachTargetVariableDefinesVariable`
- `testScatterGatherTargetVariableDefinesVariable`
- `testForeachEmptyCounterVariableDoesNotDefine`

All 176 diagnostics tests passed successfully.
