### PR TITLE
Enhance configuration management and add user prompts for missing values

### DIFF
--- a/packages/mi-extension/src/debugger/activate.ts
+++ b/packages/mi-extension/src/debugger/activate.ts
@@ -21,14 +21,15 @@ import { CancellationToken, DebugConfiguration, ProviderResult, Uri, window, wor
 import { MiDebugAdapter } from './debugAdapter';
 import { COMMANDS } from '../constants';
 import { extension } from '../MIExtensionContext';
-import {executeBuildTask, executeRemoteDeployTask, getServerPath, stopServer} from './debugHelper';
+import { executeBuildTask, executeRemoteDeployTask, getServerPath, stopServer, getConfigurableEntries } from './debugHelper';
 import { getDockerTask } from './tasks';
 import { getStateMachine, refreshUI } from '../stateMachine';
+import { openPopupView } from '../stateMachinePopup';
 import * as fs from 'fs';
 import * as path from 'path';
 import { SELECTED_SERVER_PATH, SELECTED_JAVA_HOME } from './constants';
 import { buildBallerinaModule, isConsolidatedProject, setPathsInWorkSpace, verifyJavaHomePath, verifyMIPath } from '../util/onboardingUtils';
-import { MACHINE_VIEW } from '@wso2/mi-core';
+import { MACHINE_VIEW, POPUP_EVENT_TYPE } from '@wso2/mi-core';
 import { askForProject } from '../util/workspace';
 import { webviews } from '../visualizer/webview';
 import { getWSO2AIEnvVariables } from '../ai-features/configUtils';
@@ -68,6 +69,12 @@ class MiConfigurationProvider implements vscode.DebugConfigurationProvider {
                     return undefined;
                 }
                 config.projectList = selectedItems.map(item => item.label);
+            }
+        }
+
+        for (const projectPath of config.projectList as string[]) {
+            if (!(await confirmConfigurableValues(projectPath))) {
+                return undefined;
             }
         }
 
@@ -417,6 +424,34 @@ export function activateDebugger(context: vscode.ExtensionContext) {
 
     const factory = new InlineDebugAdapterFactory();
     context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('mi', factory));
+}
+
+async function confirmConfigurableValues(projectUri: string): Promise<boolean> {
+    const configurables = await getConfigurableEntries(projectUri);
+    const missing = configurables.filter(config => !config.value);
+    if (missing.length === 0) {
+        return true;
+    }
+
+    const proceed = 'Proceed';
+    const addValues = 'Add Values';
+    const response = await vscode.window.showWarningMessage(
+        `There are configurables with no value in the .env file of the project '${path.basename(projectUri)}'. How do you want to proceed?`,
+        { modal: true },
+        proceed,
+        addValues
+    );
+
+    if (response === proceed) {
+        return true;
+    }
+    if (response === addValues) {
+        openPopupView(projectUri, POPUP_EVENT_TYPE.OPEN_VIEW, {
+            view: MACHINE_VIEW.ManageConfigurables,
+            customProps: { configs: configurables }
+        });
+    }
+    return false;
 }
 
 class InlineDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory {

--- a/packages/mi-extension/src/debugger/debugHelper.ts
+++ b/packages/mi-extension/src/debugger/debugHelper.ts
@@ -912,3 +912,9 @@ async function compareFilesByMD5(file1: string, file2: string): Promise<boolean>
         }
     });
 }
+
+export async function getConfigurableEntries(projectUri: string): Promise<{key: string; type: string; value: string; range: any; }[]> {
+    const langClient = await MILanguageClient.getInstance(projectUri);
+    const res = await langClient.getConfigurableList();
+    return res;
+}

--- a/packages/mi-extension/src/lang-client/ExtendedLanguageClient.ts
+++ b/packages/mi-extension/src/lang-client/ExtendedLanguageClient.ts
@@ -524,7 +524,7 @@ export class ExtendedLanguageClient extends LanguageClient {
         return this.sendRequest('synapse/pdfToImagesBase64', {base64: req});
     }
 
-    async getConfigurableList(): Promise<any[]> {
+    async getConfigurableList(): Promise<{key: string; type: string; value: string; range: Range | Range[]; }[]> {
         return this.sendRequest('synapse/getConfigurableList');
     }
 


### PR DESCRIPTION
This pull request introduces a pre-launch check for missing configurable values in `.env` files for each project before starting a debug session. If any required configurables are missing, the user is prompted to either proceed or add the missing values using a popup visual editor. The main changes add utility functions to parse and validate configurables, integrate the check into the debug configuration provider, and handle the popup UI flow.

**Configurable value validation and UI integration:**

* Added logic in `MiConfigurationProvider.resolveDebugConfiguration` to check for missing configurable values in `.env` files for each project and prompt the user to add them before launching the debugger.
* Implemented `getConfigurablesWithValues` to parse required configurables from `config.properties` and match them with values from `.env`.
* Added `confirmConfigurableValues` to prompt the user if any configurables are missing, offering the option to open the Manage Configurables popup or proceed.
* Added `openManageConfigurables` to open the appropriate visual editor for managing configurables, ensuring the webview is ready before opening the popup.

**Imports and dependencies:**

* Updated imports to include new types and functions required for the configurables management and popup integration.