### PR TITLE
Sync changes in the 4.1.3 version release

### DIFF
--- a/packages/mi-extension/CHANGELOG.md
+++ b/packages/mi-extension/CHANGELOG.md
@@ -1,6 +1,37 @@
 # Change Log
 
-All notable changes to the "micro-integrator" extension will be documented in this file.
+All notable changes to the "micro-integrator" extension will be documented in this file.   
+
+## [4.1.3] - 2026-07-15   
+
+### Fixed   
+
+Fixed: ASB inbound-endpoint create form is not rendering   
+Fixed: Connector generation tool fails with JDK 25   
+
+## [4.1.2] - 2026-07-04   
+
+### Fixed   
+
+Fixed: Table field values are incorrectly shown in inbound endpoint form ([#1079](https://github.com/wso2/mi-vscode/issues/1079))    
+Fixed: Minor bug fixes in the extension and the language server   
+Fixed: Update the custom inbound-endpoints importing process   
+
+## [4.1.1] - 2026-06-30   
+
+### Fixed   
+
+Fixed: Error in adding connector operations without child parameters ([#1508](https://github.com/wso2/mi-vscode/issues/1508))    
+Fixed: Custom Message Store: 'providerClass' field is empty and shows required error when reopening edit form ([#1506](https://github.com/wso2/mi-vscode/issues/1506))    
+Fixed: Connection form: Cannot update connection when another connection form is already open ([#1505](https://github.com/wso2/mi-vscode/issues/1505))    
+Fixed: HTTP connector is always added in window reload ([#1440](https://github.com/wso2/mi-vscode/issues/1440))    
+Fixed: Expression editor in Script Mediator appends additional parentheses ([#1376](https://github.com/wso2/mi-vscode/issues/1376))    
+Fixed: No error shown we retry connectors without internet connection ([#1314](https://github.com/wso2/mi-vscode/issues/1314))    
+Fixed: Show a message when the CApp generation is successful ([#1289](https://github.com/wso2/mi-vscode/issues/1289))    
+Fixed: Improve Query UI in dataservices ([#721](https://github.com/wso2/mi-vscode/issues/721))    
+Fixed: Datasource is not marked as required in Data Service create form ([#708](https://github.com/wso2/mi-vscode/issues/708))    
+Fixed: Update unit test page artifact select dropdowns don't work properly  ([#487](https://github.com/wso2/mi-vscode/issues/487))    
+Fixed: Improvements to the MI Copilot ([#1640](https://github.com/wso2/product-integrator/issues/1640))    
 
 ## [4.1.0] - 2026-06-11   
 

--- a/packages/mi-extension/package.json
+++ b/packages/mi-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "WSO2 Integrator: MI",
   "description": "The official low-code development toolkit for WSO2 Integrator: MI. Everything you need to build, test, and deploy integrations — right from within VS Code.",
   "icon": "resources/images/wso2-micro-integrator-icon.png",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "publisher": "wso2",
   "engines": {
     "vscode": "^1.100.0"

--- a/packages/mi-language-server/org.eclipse.lemminx/pom.xml
+++ b/packages/mi-language-server/org.eclipse.lemminx/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.wso2.language.server</groupId>
 		<artifactId>mi-language-server-parent</artifactId>
-		<version>0.24.0-wso2v93</version>
+		<version>0.24.0-wso2v94</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<name>MI Language Server</name>
@@ -15,7 +15,7 @@
 		<dev.build.timestamp>${maven.build.timestamp}</dev.build.timestamp>
 		<cbi.jarsigner.skip>true</cbi.jarsigner.skip>
 		<native.maven.plugin.version>0.9.16</native.maven.plugin.version>
-		<mi.connector.generator.version>0.9.10</mi.connector.generator.version>
+		<mi.connector.generator.version>0.9.11</mi.connector.generator.version>
 		<graalvm.static />
 	</properties>
 	<build>

--- a/packages/mi-language-server/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/inbound-endpoints/inbound_endpoints_440.json
+++ b/packages/mi-language-server/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/inbound-endpoints/inbound_endpoints_440.json
@@ -143,6 +143,11 @@
       "name": "Google PubSub (Inbound)",
       "id": "org.wso2.carbon.inbound.googlepubsub.GooglePubSubMessageConsumer",
       "type": "inbound-endpoint"
+    },
+	{
+      "name": "Azure Service Bus (Inbound)",
+      "id": "org.wso2.carbon.inbound.asb.ASBEventConsumer",
+      "type": "inbound-endpoint"
     }
   ]
 }

--- a/packages/mi-language-server/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/inbound-endpoints/inbound_endpoints_450.json
+++ b/packages/mi-language-server/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/inbound-endpoints/inbound_endpoints_450.json
@@ -137,6 +137,11 @@
       "name": "Google PubSub (Inbound)",
       "id": "org.wso2.carbon.inbound.googlepubsub.GooglePubSubMessageConsumer",
       "type": "inbound-endpoint"
+    },
+	{
+      "name": "Azure Service Bus (Inbound)",
+      "id": "org.wso2.carbon.inbound.asb.ASBEventConsumer",
+      "type": "inbound-endpoint"
     }
   ]
 }

--- a/packages/mi-language-server/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/inbound-endpoints/inbound_endpoints_460.json
+++ b/packages/mi-language-server/org.eclipse.lemminx/src/main/resources/org/eclipse/lemminx/inbound-endpoints/inbound_endpoints_460.json
@@ -136,6 +136,11 @@
       "name": "Solace (Inbound)",
       "id": "org.wso2.carbon.inbound.solace.SolaceEventListener",
       "type": "inbound-endpoint"
+    },
+	{
+      "name": "Azure Service Bus (Inbound)",
+      "id": "org.wso2.carbon.inbound.asb.ASBEventConsumer",
+      "type": "inbound-endpoint"
     }
   ]
 }

--- a/packages/mi-language-server/pom.xml
+++ b/packages/mi-language-server/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.wso2.language.server</groupId>
 	<artifactId>mi-language-server-parent</artifactId>
-	<version>0.24.0-wso2v93</version>
+	<version>0.24.0-wso2v94</version>
 	<packaging>pom</packaging>
 	<name>MI Language Server - Parent</name>
 	<description>LemMinX is a XML Language Server Protocol (LSP), and can be used with any editor that supports LSP, to offer an outstanding XML editing experience</description>


### PR DESCRIPTION
This PR will sync changes in the 4.1.3 version release that address the below mentioned issues.

- ASB inbound-endpoint create form is not rendering
- Connector generation tool fails with JDK 25