### PR TITLE
fix: pass vscode.Uri instead of string to getWorkspaceFolder in SHOW_GRAPHICAL_VIEW

### DIFF
--- a/packages/mi-extension/src/visualizer/activate.ts
+++ b/packages/mi-extension/src/visualizer/activate.ts
@@ -336,19 +336,17 @@ export function activateVisualizer(context: vscode.ExtensionContext, firstProjec
     );
     // Activate editor/title items
     context.subscriptions.push(
-        commands.registerCommand(COMMANDS.SHOW_GRAPHICAL_VIEW, async (file: vscode.Uri | string) => {
-            let projectUri;
-            if (typeof file !== 'string') {
-                file = file.fsPath;
-                projectUri = vscode.workspace.getWorkspaceFolder(file as any)?.uri.fsPath
-            } else {
-                projectUri = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(file))?.uri.fsPath;
-            }
-            if (!projectUri) {
-                return;
-            }
-            navigate(projectUri, { location: { view: null, documentUri: file } });
-        })
+	    commands.registerCommand(COMMANDS.SHOW_GRAPHICAL_VIEW, async (file: vscode.Uri | string) => {
+    const fileUri = typeof file !== 'string' ? file : vscode.Uri.file(file);
+    if (typeof file !== 'string') {
+        file = file.fsPath;
+    }
+    const projectUri = vscode.workspace.getWorkspaceFolder(fileUri)?.uri.fsPath;
+    if (!projectUri) {
+        return;
+    }
+    navigate(projectUri, { location: { view: null, documentUri: file } });
+})
     );
 
     context.subscriptions.push(


### PR DESCRIPTION
## Purpose
> Fixes a crash when clicking "Open Graphical View" on an XML resource file. #1554 

When the `SHOW_GRAPHICAL_VIEW` command receives a `vscode.Uri` argument, the handler
converts it to a `string` via `file.fsPath` and then passes that string to
`vscode.workspace.getWorkspaceFolder()`, forcing the type with `as any`. Internally,
`getWorkspaceFolder()` performs a binary search over workspace folders using a
comparator that expects `Uri`-only properties (`scheme`, `authority`, `path`). Since
these are `undefined` on a plain string, the comparator throws, and the command fails
silently with an uncaught error in the extension host — so "Open Graphical View" never
opens.

## Goals
Ensure `getWorkspaceFolder()` always receives a proper `vscode.Uri`, regardless of
whether the command was invoked with a `Uri` or a `string` path, so the graphical view
opens reliably for XML resources.

## Approach
Instead of converting `file` to a string before calling `getWorkspaceFolder()`, we now
keep a `vscode.Uri` (`fileUri`) around specifically for that call, and only convert to
a string (`fsPath`) for the `documentUri` field passed to `navigate()`.

```diff
     context.subscriptions.push(
         commands.registerCommand(COMMANDS.SHOW_GRAPHICAL_VIEW, async (file: vscode.Uri | string) => {
-            let projectUri;
-            if (typeof file !== 'string') {
-                file = file.fsPath;
-                projectUri = vscode.workspace.getWorkspaceFolder(file as any)?.uri.fsPath
-            } else {
-                projectUri = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(file))?.uri.fsPath;
-            }
+            const fileUri = typeof file !== 'string' ? file : vscode.Uri.file(file);
+            if (typeof file !== 'string') {
+                file = file.fsPath;
+            }
+            const projectUri = vscode.workspace.getWorkspaceFolder(fileUri)?.uri.fsPath;
             if (!projectUri) {
                 return;
             }
             navigate(projectUri, { location: { view: null, documentUri: file } });
         })
     );
```

No UI changes; this is a logic-only fix.

## User stories
As a developer, when I click "Open Graphical View" on an XML resource file, the
graphical editor opens instead of throwing an uncaught error.

## Release note
Fixed an issue where clicking "Open Graphical View" on an XML resource could throw an
uncaught error due to an incorrect type being passed to
`vscode.workspace.getWorkspaceFolder()`.

## Documentation
N/A — internal bug fix, no user-facing behavior or documented API changes.

## Training
N/A

## Certification
N/A — bug fix with no impact on certification exam content.

## Marketing
N/A

## Automation tests
- Unit tests
  > Not added yet — happy to add a unit test asserting `getWorkspaceFolder` is called
  > with a `vscode.Uri` instance for both `Uri` and `string` inputs, if maintainers
  > want it as part of this PR.
- Integration tests
  > Manually verified: reproduced the original crash by invoking "Open Graphical View"
  > on an XML resource (see linked issue/stack trace), confirmed the fix resolves it.

## Security checks
- Followed secure coding standards in https://wso2.com/technical-reports/wso2-secure-engineering-guidelines: yes
- Ran FindSecurityBugs plugin and verified report? N/A (TypeScript/VS Code extension, not applicable)
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets: yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
> [inserisci qui la tua versione di VS Code, OS (es. Linux/Debian), Node.js version]

## Learning
Root-caused via the extension host error log, which showed the exception originating
from VS Code's internal `getWorkspaceFolder` binary-search comparator
(`extensionHostProcess.js`). Reproduced the bug locally by launching the extension in
debug mode (Extension Development Host, F5) and setting a breakpoint on the
`getWorkspaceFolder` call, confirming `file` was a `string` rather than a `Uri` at that
point despite being cast with `as any`.