### PR TITLE
fix(mi-bridge): gate the websocket handshake instead of only checking requests

### DIFF
--- a/packages/mi-core/src/rpc-types/webview-bridge/index.ts
+++ b/packages/mi-core/src/rpc-types/webview-bridge/index.ts
@@ -33,7 +33,6 @@ export const WEBVIEW_WS_EVENTS = {
 export interface WebviewWsRequest {
     action: string;
     params?: unknown;
-    token?: string;
 }
 
 export interface WebviewWsResponseMessage {

--- a/packages/mi-extension/src/webview-communication/DefaultServer.ts
+++ b/packages/mi-extension/src/webview-communication/DefaultServer.ts
@@ -58,7 +58,9 @@ export class DefaultServer {
     private readonly router = createRequestRouter<WebviewWsRequest, WebviewWsResponse>();
     private proxyManager: TransportManager | undefined;
     private wsManager: TransportManager | undefined;
-    private wsBootstrap: WebviewWsBootstrap | undefined;
+    /** In-flight or completed bootstrap. Cached as a promise so that concurrent
+     *  callers share one server instead of racing to create two. */
+    private wsBootstrap: Promise<WebviewWsBootstrap> | undefined;
     private readonly disposables: Disposable[] = [];
 
     private constructor() {
@@ -80,23 +82,33 @@ export class DefaultServer {
 
     /** Starts (if needed) the websocket server for the embedded integrator form
      *  and returns the connection coordinates. */
-    getWsBootstrap(): WebviewWsBootstrap {
+    getWsBootstrap(): Promise<WebviewWsBootstrap> {
         if (!this.wsBootstrap) {
-            const mgr = createExtensionTransportManager<WebviewWsRequest, WebviewWsResponse>({
-                initialMode: "websocket",
-                wsPort: 0,
-                handleRequest: (request) => {
-                    if (!request || request.token !== this.token) {
-                        return this.errorResponse(request?.action ?? "unknown", "Unauthorized MI bridge request.");
-                    }
-                    return this.router.handle(request);
-                },
+            this.wsBootstrap = this.startWsServer().catch((error: unknown) => {
+                // Let a later call retry instead of caching the failure forever.
+                this.wsManager?.dispose();
+                this.wsBootstrap = undefined;
+                this.wsManager = undefined;
+                throw error;
             });
-            this.wsManager = mgr;
-            const wb = mgr.getWebviewBootstrap();
-            this.wsBootstrap = { host: wb.wsServer, port: wb.wsPort, token: this.token };
         }
         return this.wsBootstrap;
+    }
+
+    private async startWsServer(): Promise<WebviewWsBootstrap> {
+        const mgr = createExtensionTransportManager<WebviewWsRequest, WebviewWsResponse>({
+            initialMode: "websocket",
+            wsPort: 0,
+            // Authenticates the handshake; upgrades without this token are refused.
+            authToken: this.token,
+            handleRequest: (request) => this.router.handle(request),
+        });
+        this.wsManager = mgr;
+        // The OS assigns the port, which is only known once the server is bound,
+        // so the bootstrap must not be read before this resolves.
+        await mgr.startWebSocketServer();
+        const wb = mgr.getWebviewBootstrap();
+        return { host: wb.wsServer, port: wb.wsPort, token: this.token };
     }
 
     dispose(): void {

--- a/packages/mi-visualizer/src/views/Embedded/wsManager/WsClient.ts
+++ b/packages/mi-visualizer/src/views/Embedded/wsManager/WsClient.ts
@@ -83,6 +83,10 @@ export class MiWsClient {
             mode: bootstrap.mode,
             server: bootstrap.wsServer,
             port: bootstrap.wsPort,
+            // Presented during the websocket handshake; the host rejects the
+            // upgrade without it. Ignored in proxy mode, which does not use a
+            // socket.
+            token: bootstrap.token,
         });
         this.transport.subscribe(
             () => undefined,
@@ -130,9 +134,6 @@ export class MiWsClient {
         const payload: WebviewWsRequest = { action };
         if (params !== undefined) {
             payload.params = params;
-        }
-        if (this.bootstrap.token) {
-            payload.token = this.bootstrap.token;
         }
         const response = await this.transport.request(payload);
         if (!response || response.type !== WEBVIEW_WS_EVENTS.WS_RESPONSE || response.action !== action) {


### PR DESCRIPTION
## Purpose

The MI form websocket server (`DefaultServer`) generates a per-session token, but it was only validated inside `handleRequest`. An unauthenticated client could therefore still **complete the handshake and hold an open socket** — it was merely refused per request.

At the previous submodule pin that socket also **bound every interface** rather than loopback, so it was reachable from other hosts on the network. And because WebSocket connections are not subject to same-origin policy, it was additionally reachable as cross-site websocket hijacking from any page the user happened to visit.

This is the same issue already fixed for the WSO2 Integrator and Ballerina extensions:
- wso2/vscode-extensions#2435 / #2442 — the shared `@wso2/webview-giga-bridge` changes
- wso2/product-integrator#1953 — the Integrator (`wi`) extension
- ballerina-platform/ballerina-vscode#741 — the Ballerina extension

## Approach

**1. Gate the handshake (`DefaultServer.ts`)** — pass `authToken` to the transport manager. The bridge validates it during the websocket upgrade and rejects non-matching connections, so unauthenticated clients never establish a socket. A cross-site page cannot read the token, so this also blocks CSWSH.

The per-request check is **dropped rather than kept**: once the handshake is gated it can only ever run on an already-authenticated socket, so it added no protection while keeping a second copy of the same secret moving through every payload. This matches the shape the other two extensions landed on.

**2. Client presents the token (`MiWsClient`)** — the token was already plumbed to the webview but never handed to the transport adapter; without this the new gate would refuse every legitimate client. It also stops attaching the token per request.

**3. `WebviewWsRequest`** — drops the `token` field, which no longer has a reader.

**4. `getWsBootstrap()` is now async** — the bridge binds loopback, which puts Node on the `listen(port, host)` path where the host is resolved before binding, so the OS-assigned port is only known once the server reports `listening`. Reading the bootstrap eagerly would hand the form port 0. The cached value is the promise itself, so concurrent callers share one server rather than racing to create two, and a failed start clears the cache and disposes the manager so a later call can retry.

`GET_MI_FORM_WS_BOOTSTRAP` now resolves a promise, which VS Code commands support, and the Integrator host already awaits this call.

### Note on the difference from the Ballerina fix

Unlike Ballerina's `DefaultServer`, this one has **no `publish`/broadcast**, so there was no passive event-disclosure path here — an unauthenticated client could hold a socket but would not receive pushed data. The exposure being closed is the reachable port and the ability to connect at all.

## Submodule bump

`submodules/vscode-extensions`: `fae80157d` → `29725ae50`. **Required** — the `authToken` and `token` options do not exist at the previous pin.

The bump is narrow by inspection: of the six submodule packages this repo consumes, only `vscode-webview-bridge` differs between the two pins. `ui-toolkit`, `service-designer`, `wso2-platform-core`, `font-wso2-vscode` and `playwright-vscode-tester` are unchanged, and this repo does not depend on `copilot-utilities`, so nothing else comes along with it.

## Release note

Fixed the MI form websocket bridge to authenticate connections at the handshake and to bind loopback only, preventing unauthenticated or remote clients from connecting.

## Documentation

N/A — no user-facing behaviour or configuration change. The token is generated and consumed internally.

## Automation tests

- Unit tests
  > None added; there is no existing harness for `DefaultServer` or the embedded WS client in this repo.
- Integration tests
  > None added. The websocket path is exercised only by the embedded MI form, which has no automated coverage today.

**Verified:**
- `mi-core` builds with **0 errors** and emits `WebviewWsRequest` without `token`
- `DefaultServer.ts`, `visualizer/activate.ts` and the embedded `WsClient.ts` all typecheck with **zero errors**
- `@wso2/webview-giga-bridge` **resolves** in both packages, so the new `authToken` option is actually type-checked rather than skipped over an unresolved import — confirmed by temporarily misspelling it and seeing `tsc` reject it, then restoring
- Handshake enforcement was verified at the library level while landing wso2/vscode-extensions#2442: clients presenting no token or a wrong token are rejected with HTTP 401, never open a socket, and receive no data

**Known gap:** the remaining errors in `mi-extension` (35) and `mi-visualizer` (509) are pre-existing and all trace to sibling packages not built in this partial local build (`@wso2/playwright-vscode-tester`, `@wso2/wso2-platform-core`, `@wso2/ui-toolkit`, `@wso2/mi-rpc-client`, `@wso2/mi-diagram`). None are in files touched here. CI runs a full build.

This has **not** been exercised in a running app; the embedded MI form should be opened once to confirm the handshake succeeds end to end.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? **yes**
- Ran FindSecurityBugs plugin and verified report? **N/A** — TypeScript codebase, not Java
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? **yes** — the token is generated at runtime via `randomBytes(32)` and never persisted or committed

## Related PRs

- wso2/vscode-extensions#2435, #2442 — the bridge changes this depends on (merged)
- wso2/product-integrator#1953 — same fix for the Integrator extension
- ballerina-platform/ballerina-vscode#741 — same fix for the Ballerina extension

## Test environment

macOS (darwin 25.5.0), Node 22.21.1, Rush 5.155.1 / pnpm.