### PR TITLE
[MI Copilot] Handle runtime-versioned synapse-core dependency for class mediator

### DIFF
--- a/packages/mi-extension/src/ai-features/agent-mode/context/synapse_guide.ts
+++ b/packages/mi-extension/src/ai-features/agent-mode/context/synapse_guide.ts
@@ -61,7 +61,7 @@ export const SYNAPSE_GUIDE = `
    - Use the Redis connector instead of the cache mediator for Redis cache.
    - Do not leave placeholders like "To be implemented". Always implement the complete solution.
    - Use WSO2 Connectors whenever possible instead of directly calling APIs.
-   - Do not use new class mediators unless absolutely necessary. When you do create one, also flip the root \`pom.xml\` from \`<packaging>pom</packaging>\` to \`<packaging>jar</packaging>\` and ensure a \`synapse-core\` dependency is declared, otherwise the CApp will not pack the jar.
+   - Do not use new class mediators unless absolutely necessary. When you do create one (under \`src/main/java/\`), also flip the root \`pom.xml\` from \`<packaging>pom</packaging>\` to \`<packaging>jar</packaging>\` and ensure the \`org.apache.synapse:synapse-core\` dependency is declared (\`4.1.0-wso2v48\` for MI runtime >= 4.6.0, \`4.0.0-wso2v165\` for < 4.6.0), otherwise the CApp will not pack the jar and the class mediator will fail at runtime.
    - Define driver, username, dburl, and passwords inside the dbreport or dblookup mediator <connection> tag instead of generating deployment toml file changes.
    - Do not use fake XML placeholders (e.g., <TODO>, <placeholder>, <...>).
    - The respond mediator should be empty; it does not support child elements.

--- a/packages/mi-extension/src/ai-features/agent-mode/context/synapse_guide_old.ts
+++ b/packages/mi-extension/src/ai-features/agent-mode/context/synapse_guide_old.ts
@@ -54,7 +54,7 @@ export const SYNAPSE_GUIDE = `
    - When updating an XML artifact, provide the entire file with updated content.
    - Do not leave placeholders like "To be implemented". Always implement the complete solution.
    - Use WSO2 Connectors whenever possible instead of directly calling APIs.
-   - Do not use new class mediators unless it is absolutely necessary. When you do create one, also flip the root \`pom.xml\` from \`<packaging>pom</packaging>\` to \`<packaging>jar</packaging>\` and ensure a \`synapse-core\` dependency is declared, otherwise the CApp will not pack the jar.
+   - Do not use new class mediators unless it is absolutely necessary. When you do create one (under \`src/main/java/\`), also flip the root \`pom.xml\` from \`<packaging>pom</packaging>\` to \`<packaging>jar</packaging>\` and ensure \`org.apache.synapse:synapse-core\` dependency version \`4.0.0-wso2v165\` is declared, otherwise the CApp will not pack the jar.
    - Define driver, username, dburl, and passwords inside the dbreport or dblookup mediator <connection> tag instead of generating deployment toml file changes.
    - Do not use fake XML placeholders (for example, <TODO>, <placeholder>, or <...>) in generated artifacts.
    - To include an API key in uri-template, define:

--- a/packages/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
+++ b/packages/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
@@ -53,6 +53,7 @@ import {
 } from './ripgrep_runner';
 import { isSensitiveTokenName } from './shell_sandbox';
 import { stripAnsiAndControl } from '../../utils/sanitize-text';
+import { compareVersions } from '../../../util/onboardingUtils';
 
 // ============================================================================
 // Validation Functions
@@ -639,45 +640,139 @@ function trackModifiedFile(modifiedFiles: string[] | undefined, filePath: string
     }
 }
 
+export const SYNAPSE_CORE_GROUP_ID = 'org.apache.synapse';
+export const SYNAPSE_CORE_ARTIFACT_ID = 'synapse-core';
+export const SYNAPSE_CORE_VERSION_GE_460 = '4.1.0-wso2v48';
+export const SYNAPSE_CORE_VERSION_LT_460 = '4.0.0-wso2v165';
+
+/**
+ * Returns the expected synapse-core version based on the MI runtime version.
+ * - Runtime >= 4.6.0: 4.1.0-wso2v48
+ * - Runtime < 4.6.0: 4.0.0-wso2v165
+ */
+export function getExpectedSynapseCoreVersion(runtimeVersion?: string | null): string {
+    if (!runtimeVersion || compareVersions(runtimeVersion, '4.6.0') >= 0) {
+        return SYNAPSE_CORE_VERSION_GE_460;
+    }
+    return SYNAPSE_CORE_VERSION_LT_460;
+}
+
 /**
  * Returns true for class mediator java sources under src/main/java/.
  */
-function isClassMediatorPath(filePath: string): boolean {
+export function isClassMediatorPath(filePath: string): boolean {
     const normalized = filePath.replace(/\\/g, '/').toLowerCase();
     return /(^|\/)src\/main\/java\//.test(normalized) && normalized.endsWith('.java');
 }
 
+export interface ClassMediatorPomStatus {
+    isJarPackaging: boolean;
+    currentPackaging?: string;
+    runtimeVersion?: string;
+    expectedSynapseCoreVersion: string;
+    hasSynapseCore: boolean;
+    currentSynapseCoreVersion?: string;
+    isSynapseCoreVersionCorrect: boolean;
+    isConfigured: boolean;
+}
+
 /**
- * Builds a `<system-reminder>` for class mediator writes/edits when the
- * project root pom.xml is not yet configured to pack a jar. Returns ''
- * when packaging is already "jar" so the model is not nagged unnecessarily.
- * Falls back to a generic reminder if pom.xml cannot be read or parsed,
- * since the safe default is to surface the requirement.
+ * Parses pom.xml content to inspect packaging and synapse-core dependency configuration.
  */
-function buildClassMediatorPomReminder(projectPath: string): string {
-    const pomPath = path.join(projectPath, 'pom.xml');
-    let currentPackaging: string | undefined;
-    try {
-        const pomContent = fs.readFileSync(pomPath, 'utf-8');
-        const match = pomContent.match(/<packaging>\s*([^<\s]+)\s*<\/packaging>/);
-        currentPackaging = match?.[1]?.toLowerCase();
-    } catch {
-        // pom.xml missing or unreadable; fall through to the generic reminder.
+export function checkClassMediatorPomStatus(pomContent: string): ClassMediatorPomStatus {
+    const cleanPom = pomContent.replace(/<!--[\s\S]*?-->/g, '');
+    const packagingMatch = cleanPom.match(/<packaging>\s*([^<\s]+)\s*<\/packaging>/i);
+    const currentPackaging = packagingMatch?.[1]?.toLowerCase();
+    const isJarPackaging = currentPackaging === 'jar';
+
+    const runtimeVersionMatch = cleanPom.match(/<project\.runtime\.version>\s*([^<\s]+)\s*<\/project\.runtime\.version>/i);
+    const runtimeVersion = runtimeVersionMatch?.[1]?.trim();
+    const expectedSynapseCoreVersion = getExpectedSynapseCoreVersion(runtimeVersion);
+
+    let hasSynapseCore = false;
+    let currentSynapseCoreVersion: string | undefined;
+    for (const match of cleanPom.matchAll(/<dependency\b[^>]*>([\s\S]*?)<\/dependency>/gi)) {
+        const block = match[1];
+        const groupId = block.match(/<groupId>\s*([^<\s]+)\s*<\/groupId>/i)?.[1]?.trim();
+        const artifactId = block.match(/<artifactId>\s*([^<\s]+)\s*<\/artifactId>/i)?.[1]?.trim();
+        if (groupId === SYNAPSE_CORE_GROUP_ID && artifactId === SYNAPSE_CORE_ARTIFACT_ID) {
+            hasSynapseCore = true;
+            currentSynapseCoreVersion = block.match(/<version>\s*([^<\s]+)\s*<\/version>/i)?.[1]?.trim();
+            break;
+        }
     }
 
-    if (currentPackaging === 'jar') {
+    const isSynapseCoreVersionCorrect = hasSynapseCore && currentSynapseCoreVersion === expectedSynapseCoreVersion;
+    const isConfigured = isJarPackaging && isSynapseCoreVersionCorrect;
+
+    return {
+        isJarPackaging,
+        currentPackaging,
+        runtimeVersion,
+        expectedSynapseCoreVersion,
+        hasSynapseCore,
+        currentSynapseCoreVersion,
+        isSynapseCoreVersionCorrect,
+        isConfigured,
+    };
+}
+
+/**
+ * Builds a `<system-reminder>` for class mediator writes/edits when the
+ * project root pom.xml is not yet configured with <packaging>jar</packaging>
+ * and the expected synapse-core dependency version.
+ * Returns '' when the pom.xml is already correctly configured so the model is not nagged unnecessarily.
+ * Falls back to a generic reminder if pom.xml cannot be read or parsed.
+ */
+export function buildClassMediatorPomReminder(projectPath: string): string {
+    const pomPath = path.join(projectPath, 'pom.xml');
+    let pomContent: string;
+    try {
+        pomContent = fs.readFileSync(pomPath, 'utf-8');
+    } catch {
+        return (
+            `\n\n<system-reminder>You just wrote/edited a class mediator Java source, but the project root pom.xml could not be read. ` +
+            `Ensure the root pom.xml has <packaging>jar</packaging> and declares the ` +
+            `'${SYNAPSE_CORE_GROUP_ID}:${SYNAPSE_CORE_ARTIFACT_ID}' dependency ` +
+            `(${SYNAPSE_CORE_VERSION_GE_460} for MI 4.6.0+, ${SYNAPSE_CORE_VERSION_LT_460} for < 4.6.0), ` +
+            `otherwise the CApp will not pack the jar and the class mediator will silently fail to deploy.</system-reminder>`
+        );
+    }
+
+    const status = checkClassMediatorPomStatus(pomContent);
+    if (status.isConfigured) {
         return '';
     }
 
-    const currentDesc = currentPackaging
-        ? `currently <packaging>${currentPackaging}</packaging>`
-        : 'current packaging could not be determined';
+    const runtimeDesc = status.runtimeVersion ?? '4.6.0+';
+    const issues: string[] = [];
+    if (!status.isJarPackaging) {
+        const packagingDesc = status.currentPackaging ? `<packaging>${status.currentPackaging}</packaging>` : 'not set to jar';
+        issues.push(`- Change packaging from ${packagingDesc} to <packaging>jar</packaging>.`);
+    }
+    if (!status.hasSynapseCore) {
+        issues.push(
+            `- Add the '${SYNAPSE_CORE_GROUP_ID}:${SYNAPSE_CORE_ARTIFACT_ID}' dependency with version '${status.expectedSynapseCoreVersion}' (for MI runtime ${runtimeDesc}):\n` +
+            `  <dependency>\n` +
+            `      <groupId>${SYNAPSE_CORE_GROUP_ID}</groupId>\n` +
+            `      <artifactId>${SYNAPSE_CORE_ARTIFACT_ID}</artifactId>\n` +
+            `      <version>${status.expectedSynapseCoreVersion}</version>\n` +
+            `  </dependency>`
+        );
+    } else if (!status.isSynapseCoreVersionCorrect) {
+        const fromClause = status.currentSynapseCoreVersion
+            ? `from '${status.currentSynapseCoreVersion}' `
+            : '(currently missing a <version> tag) ';
+        issues.push(
+            `- Update the '${SYNAPSE_CORE_GROUP_ID}:${SYNAPSE_CORE_ARTIFACT_ID}' dependency version ${fromClause}to '${status.expectedSynapseCoreVersion}' (for MI runtime ${runtimeDesc}).`
+        );
+    }
+
     return (
-        '\n\n<system-reminder>You just wrote/edited a class mediator java source, ' +
-        `but the project root pom.xml ${currentDesc}. ` +
-        'Change it to <packaging>jar</packaging> and ensure a synapse-core dependency ' +
-        'is declared, otherwise the CApp will not pack the jar and the class mediator ' +
-        'will silently fail to deploy.</system-reminder>'
+        `\n\n<system-reminder>You just wrote/edited a class mediator Java source (src/main/java/...). ` +
+        `Please update the project root pom.xml with the following requirement(s):\n` +
+        issues.join('\n') +
+        `\nOtherwise, the CApp will not pack the compiled class mediator jar and it will silently fail to deploy at runtime.</system-reminder>`
     );
 }
 

--- a/packages/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
+++ b/packages/mi-extension/src/ai-features/agent-mode/tools/file_tools.ts
@@ -53,7 +53,11 @@ import {
 } from './ripgrep_runner';
 import { isSensitiveTokenName } from './shell_sandbox';
 import { stripAnsiAndControl } from '../../utils/sanitize-text';
-import { compareVersions } from '../../../util/onboardingUtils';
+import {
+    getSynapseCoreVersionForRuntime,
+    SYNAPSE_CORE_VERSION_460_AND_ABOVE,
+    SYNAPSE_CORE_VERSION_BELOW_460,
+} from '../../../util/onboardingUtils';
 
 // ============================================================================
 // Validation Functions
@@ -642,20 +646,19 @@ function trackModifiedFile(modifiedFiles: string[] | undefined, filePath: string
 
 export const SYNAPSE_CORE_GROUP_ID = 'org.apache.synapse';
 export const SYNAPSE_CORE_ARTIFACT_ID = 'synapse-core';
-export const SYNAPSE_CORE_VERSION_GE_460 = '4.1.0-wso2v48';
-export const SYNAPSE_CORE_VERSION_LT_460 = '4.0.0-wso2v165';
+
+// Sourced from onboardingUtils so the class mediator reminder and the onboarding
+// pom updater share a single source of truth for synapse-core versions.
+export const SYNAPSE_CORE_VERSION_GE_460 = SYNAPSE_CORE_VERSION_460_AND_ABOVE;
+export const SYNAPSE_CORE_VERSION_LT_460 = SYNAPSE_CORE_VERSION_BELOW_460;
 
 /**
  * Returns the expected synapse-core version based on the MI runtime version.
- * - Runtime >= 4.6.0: 4.1.0-wso2v48
+ * - Runtime >= 4.6.0 (or unknown): 4.1.0-wso2v48
  * - Runtime < 4.6.0: 4.0.0-wso2v165
+ * Delegates to the shared onboardingUtils version selection.
  */
-export function getExpectedSynapseCoreVersion(runtimeVersion?: string | null): string {
-    if (!runtimeVersion || compareVersions(runtimeVersion, '4.6.0') >= 0) {
-        return SYNAPSE_CORE_VERSION_GE_460;
-    }
-    return SYNAPSE_CORE_VERSION_LT_460;
-}
+export const getExpectedSynapseCoreVersion = getSynapseCoreVersionForRuntime;
 
 /**
  * Returns true for class mediator java sources under src/main/java/.
@@ -681,6 +684,13 @@ export interface ClassMediatorPomStatus {
  */
 export function checkClassMediatorPomStatus(pomContent: string): ClassMediatorPomStatus {
     const cleanPom = pomContent.replace(/<!--[\s\S]*?-->/g, '');
+    // Strip <dependencyManagement>: its entries pin versions but do not add
+    // synapse-core to the project's actual dependencies, so they must not be
+    // treated as a declared dependency when deciding if the reminder is needed.
+    const projectDependencies = cleanPom.replace(
+        /<dependencyManagement\b[^>]*>[\s\S]*?<\/dependencyManagement>/gi,
+        ''
+    );
     const packagingMatch = cleanPom.match(/<packaging>\s*([^<\s]+)\s*<\/packaging>/i);
     const currentPackaging = packagingMatch?.[1]?.toLowerCase();
     const isJarPackaging = currentPackaging === 'jar';
@@ -691,7 +701,7 @@ export function checkClassMediatorPomStatus(pomContent: string): ClassMediatorPo
 
     let hasSynapseCore = false;
     let currentSynapseCoreVersion: string | undefined;
-    for (const match of cleanPom.matchAll(/<dependency\b[^>]*>([\s\S]*?)<\/dependency>/gi)) {
+    for (const match of projectDependencies.matchAll(/<dependency\b[^>]*>([\s\S]*?)<\/dependency>/gi)) {
         const block = match[1];
         const groupId = block.match(/<groupId>\s*([^<\s]+)\s*<\/groupId>/i)?.[1]?.trim();
         const artifactId = block.match(/<artifactId>\s*([^<\s]+)\s*<\/artifactId>/i)?.[1]?.trim();

--- a/packages/mi-extension/src/ai-features/copilot/context/synapse_guide.ts
+++ b/packages/mi-extension/src/ai-features/copilot/context/synapse_guide.ts
@@ -54,7 +54,7 @@ export const SYNAPSE_GUIDE = `
    - When updating an XML artifact, provide the entire file with updated content.
    - Do not leave placeholders like "To be implemented". Always implement the complete solution.
    - Use WSO2 Connectors whenever possible instead of directly calling APIs.
-   - Do not use new class mediators unless it is absolutely necessary.
+   - Do not use new class mediators unless it is absolutely necessary. When you do create one (under \`src/main/java/\`), set \`<packaging>jar</packaging>\` and declare \`org.apache.synapse:synapse-core\` (\`4.1.0-wso2v48\` for MI runtime >= 4.6.0, \`4.0.0-wso2v165\` for < 4.6.0) in root \`pom.xml\`, otherwise the CApp will not pack the jar.
    - Define driver, username, dburl, and passwords inside the dbreport or dblookup mediator <connection> tag instead of generating deployment toml file changes.
    - Do not use <> tags as placeholders.
    - To include an API key in uri-template, define:

--- a/packages/mi-extension/src/ai-features/copilot/context/synapse_guide_v1.ts
+++ b/packages/mi-extension/src/ai-features/copilot/context/synapse_guide_v1.ts
@@ -54,7 +54,7 @@ export const SYNAPSE_GUIDE = `
    - When updating an XML artifact, provide the entire file with updated content.
    - Do not leave placeholders like "To be implemented". Always implement the complete solution.
    - Use WSO2 Connectors whenever possible instead of directly calling APIs.
-   - Do not use new class mediators unless it is absolutely necessary.
+   - Do not use new class mediators unless it is absolutely necessary. When you do create one (under \`src/main/java/\`), set \`<packaging>jar</packaging>\` and declare \`org.apache.synapse:synapse-core\` version \`4.0.0-wso2v165\` in root \`pom.xml\`, otherwise the CApp will not pack the jar.
    - Define driver, username, dburl, and passwords inside the dbreport or dblookup mediator <connection> tag instead of generating deployment toml file changes.
    - Do not use <> tags as placeholders.
    - To include an API key in uri-template, define:

--- a/packages/mi-extension/src/test/suite/file-tools.class-mediator.test.ts
+++ b/packages/mi-extension/src/test/suite/file-tools.class-mediator.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com/) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    isClassMediatorPath,
+    getExpectedSynapseCoreVersion,
+    checkClassMediatorPomStatus,
+    buildClassMediatorPomReminder,
+    SYNAPSE_CORE_VERSION_GE_460,
+    SYNAPSE_CORE_VERSION_LT_460,
+} from '../../ai-features/agent-mode/tools/file_tools';
+
+suite('Class Mediator POM Reminder Tests', () => {
+    test('isClassMediatorPath correctly identifies class mediator Java paths', () => {
+        assert.strictEqual(isClassMediatorPath('src/main/java/org/wso2/sample/MyMediator.java'), true);
+        assert.strictEqual(isClassMediatorPath('src\\main\\java\\org\\wso2\\sample\\MyMediator.java'), true);
+        assert.strictEqual(isClassMediatorPath('/home/user/project/src/main/java/org/wso2/sample/MyMediator.java'), true);
+        assert.strictEqual(isClassMediatorPath('src/main/wso2mi/artifacts/apis/MyApi.xml'), false);
+        assert.strictEqual(isClassMediatorPath('src/test/java/org/wso2/sample/MyMediatorTest.java'), false);
+        assert.strictEqual(isClassMediatorPath('src/main/java/README.md'), false);
+    });
+
+    test('getExpectedSynapseCoreVersion returns correct version for MI runtime', () => {
+        assert.strictEqual(getExpectedSynapseCoreVersion('4.6.0'), SYNAPSE_CORE_VERSION_GE_460);
+        assert.strictEqual(getExpectedSynapseCoreVersion('4.6.1'), SYNAPSE_CORE_VERSION_GE_460);
+        assert.strictEqual(getExpectedSynapseCoreVersion('5.0.0'), SYNAPSE_CORE_VERSION_GE_460);
+        assert.strictEqual(getExpectedSynapseCoreVersion(null), SYNAPSE_CORE_VERSION_GE_460);
+        assert.strictEqual(getExpectedSynapseCoreVersion(undefined), SYNAPSE_CORE_VERSION_GE_460);
+
+        assert.strictEqual(getExpectedSynapseCoreVersion('4.5.0'), SYNAPSE_CORE_VERSION_LT_460);
+        assert.strictEqual(getExpectedSynapseCoreVersion('4.4.0'), SYNAPSE_CORE_VERSION_LT_460);
+        assert.strictEqual(getExpectedSynapseCoreVersion('4.3.0'), SYNAPSE_CORE_VERSION_LT_460);
+        assert.strictEqual(getExpectedSynapseCoreVersion('4.2.0'), SYNAPSE_CORE_VERSION_LT_460);
+        assert.strictEqual(getExpectedSynapseCoreVersion('4.1.0'), SYNAPSE_CORE_VERSION_LT_460);
+    });
+
+    test('checkClassMediatorPomStatus identifies properly configured POM for 4.6.0+', () => {
+        const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <properties>
+        <project.runtime.version>4.6.0</project.runtime.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.synapse</groupId>
+            <artifactId>synapse-core</artifactId>
+            <version>4.1.0-wso2v48</version>
+        </dependency>
+    </dependencies>
+</project>`;
+
+        const status = checkClassMediatorPomStatus(pomContent);
+        assert.strictEqual(status.isJarPackaging, true);
+        assert.strictEqual(status.runtimeVersion, '4.6.0');
+        assert.strictEqual(status.expectedSynapseCoreVersion, '4.1.0-wso2v48');
+        assert.strictEqual(status.hasSynapseCore, true);
+        assert.strictEqual(status.currentSynapseCoreVersion, '4.1.0-wso2v48');
+        assert.strictEqual(status.isSynapseCoreVersionCorrect, true);
+        assert.strictEqual(status.isConfigured, true);
+    });
+
+    test('checkClassMediatorPomStatus identifies properly configured POM for < 4.6.0', () => {
+        const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <properties>
+        <project.runtime.version>4.4.0</project.runtime.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.synapse</groupId>
+            <artifactId>synapse-core</artifactId>
+            <version>4.0.0-wso2v165</version>
+        </dependency>
+    </dependencies>
+</project>`;
+
+        const status = checkClassMediatorPomStatus(pomContent);
+        assert.strictEqual(status.isJarPackaging, true);
+        assert.strictEqual(status.runtimeVersion, '4.4.0');
+        assert.strictEqual(status.expectedSynapseCoreVersion, '4.0.0-wso2v165');
+        assert.strictEqual(status.hasSynapseCore, true);
+        assert.strictEqual(status.currentSynapseCoreVersion, '4.0.0-wso2v165');
+        assert.strictEqual(status.isSynapseCoreVersionCorrect, true);
+        assert.strictEqual(status.isConfigured, true);
+    });
+
+    test('checkClassMediatorPomStatus detects packaging:pom and missing dependency', () => {
+        const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+    <properties>
+        <project.runtime.version>4.6.0</project.runtime.version>
+    </properties>
+    <dependencies>
+    </dependencies>
+</project>`;
+
+        const status = checkClassMediatorPomStatus(pomContent);
+        assert.strictEqual(status.isJarPackaging, false);
+        assert.strictEqual(status.hasSynapseCore, false);
+        assert.strictEqual(status.isConfigured, false);
+    });
+
+    test('checkClassMediatorPomStatus detects mismatched synapse-core version', () => {
+        const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <properties>
+        <project.runtime.version>4.6.0</project.runtime.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.synapse</groupId>
+            <artifactId>synapse-core</artifactId>
+            <version>4.0.0-wso2v165</version>
+        </dependency>
+    </dependencies>
+</project>`;
+
+        const status = checkClassMediatorPomStatus(pomContent);
+        assert.strictEqual(status.isJarPackaging, true);
+        assert.strictEqual(status.hasSynapseCore, true);
+        assert.strictEqual(status.isSynapseCoreVersionCorrect, false);
+        assert.strictEqual(status.isConfigured, false);
+    });
+
+    test('checkClassMediatorPomStatus ignores XML comments properly', () => {
+        const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>1.0.0</version>
+    <!-- <packaging>jar</packaging> -->
+    <packaging>pom</packaging>
+    <properties>
+        <project.runtime.version>4.6.0</project.runtime.version>
+    </properties>
+    <dependencies>
+        <!--
+        <dependency>
+            <groupId>org.apache.synapse</groupId>
+            <artifactId>synapse-core</artifactId>
+            <version>4.1.0-wso2v48</version>
+        </dependency>
+        -->
+    </dependencies>
+</project>`;
+
+        const status = checkClassMediatorPomStatus(pomContent);
+        assert.strictEqual(status.isJarPackaging, false);
+        assert.strictEqual(status.hasSynapseCore, false);
+        assert.strictEqual(status.isConfigured, false);
+    });
+
+    test('checkClassMediatorPomStatus handles missing <version> tag in synapse-core dependency', () => {
+        const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <properties>
+        <project.runtime.version>4.6.0</project.runtime.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.synapse</groupId>
+            <artifactId>synapse-core</artifactId>
+        </dependency>
+    </dependencies>
+</project>`;
+
+        const status = checkClassMediatorPomStatus(pomContent);
+        assert.strictEqual(status.hasSynapseCore, true);
+        assert.strictEqual(status.currentSynapseCoreVersion, undefined);
+        assert.strictEqual(status.isSynapseCoreVersionCorrect, false);
+        assert.strictEqual(status.isConfigured, false);
+    });
+
+    test('buildClassMediatorPomReminder returns empty string when fully configured', () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mi-test-cm-'));
+        try {
+            const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <properties>
+        <project.runtime.version>4.6.0</project.runtime.version>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.synapse</groupId>
+            <artifactId>synapse-core</artifactId>
+            <version>4.1.0-wso2v48</version>
+        </dependency>
+    </dependencies>
+</project>`;
+            fs.writeFileSync(path.join(tempDir, 'pom.xml'), pomContent, 'utf-8');
+            const reminder = buildClassMediatorPomReminder(tempDir);
+            assert.strictEqual(reminder, '');
+        } finally {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    test('buildClassMediatorPomReminder generates reminder with 4.1.0-wso2v48 for 4.6.0 runtime', () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mi-test-cm-'));
+        try {
+            const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+    <properties>
+        <project.runtime.version>4.6.0</project.runtime.version>
+    </properties>
+</project>`;
+            fs.writeFileSync(path.join(tempDir, 'pom.xml'), pomContent, 'utf-8');
+            const reminder = buildClassMediatorPomReminder(tempDir);
+            assert.ok(reminder.includes('<system-reminder>'));
+            assert.ok(reminder.includes('<packaging>jar</packaging>'));
+            assert.ok(reminder.includes('4.1.0-wso2v48'));
+            assert.ok(reminder.includes('org.apache.synapse'));
+            assert.ok(reminder.includes('synapse-core'));
+        } finally {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    test('buildClassMediatorPomReminder generates reminder with 4.0.0-wso2v165 for < 4.6.0 runtime', () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mi-test-cm-'));
+        try {
+            const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+    <properties>
+        <project.runtime.version>4.4.0</project.runtime.version>
+    </properties>
+</project>`;
+            fs.writeFileSync(path.join(tempDir, 'pom.xml'), pomContent, 'utf-8');
+            const reminder = buildClassMediatorPomReminder(tempDir);
+            assert.ok(reminder.includes('<system-reminder>'));
+            assert.ok(reminder.includes('<packaging>jar</packaging>'));
+            assert.ok(reminder.includes('4.0.0-wso2v165'));
+            assert.ok(reminder.includes('org.apache.synapse'));
+            assert.ok(reminder.includes('synapse-core'));
+        } finally {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    test('buildClassMediatorPomReminder generates fallback reminder when pom.xml is missing', () => {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mi-test-cm-'));
+        try {
+            const reminder = buildClassMediatorPomReminder(tempDir);
+            assert.ok(reminder.includes('<system-reminder>'));
+            assert.ok(reminder.includes('could not be read'));
+            assert.ok(reminder.includes('<packaging>jar</packaging>'));
+            assert.ok(reminder.includes('org.apache.synapse:synapse-core'));
+        } finally {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/packages/mi-extension/src/test/suite/file-tools.class-mediator.test.ts
+++ b/packages/mi-extension/src/test/suite/file-tools.class-mediator.test.ts
@@ -216,6 +216,37 @@ suite('Class Mediator POM Reminder Tests', () => {
         assert.strictEqual(status.isConfigured, false);
     });
 
+    test('checkClassMediatorPomStatus ignores synapse-core declared only in dependencyManagement', () => {
+        const pomContent = `<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.example</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+    <properties>
+        <project.runtime.version>4.6.0</project.runtime.version>
+    </properties>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.synapse</groupId>
+                <artifactId>synapse-core</artifactId>
+                <version>4.1.0-wso2v48</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+    </dependencies>
+</project>`;
+
+        const status = checkClassMediatorPomStatus(pomContent);
+        assert.strictEqual(status.isJarPackaging, true);
+        assert.strictEqual(status.hasSynapseCore, false);
+        assert.strictEqual(status.currentSynapseCoreVersion, undefined);
+        assert.strictEqual(status.isConfigured, false);
+    });
+
     test('buildClassMediatorPomReminder returns empty string when fully configured', () => {
         const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mi-test-cm-'));
         try {

--- a/packages/mi-extension/src/util/onboardingUtils.ts
+++ b/packages/mi-extension/src/util/onboardingUtils.ts
@@ -48,14 +48,26 @@ export const javaVersionCompatibilityMap: { [key: string]: { supportedRange: { m
 };
 export const LATEST_MI_VERSION = "4.7.0";
 const COMPATIBLE_JDK_VERSION = "11";
-const DEFAULT_SYNAPSE_CORE_VERSION = "4.0.0-wso2v165";
+export const SYNAPSE_CORE_VERSION_460_AND_ABOVE = "4.1.0-wso2v48";
+export const SYNAPSE_CORE_VERSION_BELOW_460 = "4.0.0-wso2v165";
+const MIN_RUNTIME_FOR_LATEST_SYNAPSE_CORE = "4.6.0";
 export const synapseCoreVersionMap: { [key: string]: string } = {
-    '4.7.0': '4.1.0-wso2v48',
-    '4.6.0': '4.1.0-wso2v48'
+    '4.7.0': SYNAPSE_CORE_VERSION_460_AND_ABOVE,
+    '4.6.0': SYNAPSE_CORE_VERSION_460_AND_ABOVE
 };
 
+/**
+ * Returns the synapse-core dependency version required for the given MI runtime.
+ * MI 4.6.0 and above (and unknown/undefined runtimes, which fall back to the latest)
+ * require 4.1.0-wso2v48; older runtimes require 4.0.0-wso2v165. Using a version
+ * threshold rather than exact map lookups keeps patch/future runtimes (e.g. 4.6.1,
+ * 4.8.0) resolving to the correct version.
+ */
 export function getSynapseCoreVersionForRuntime(runtimeVersion?: string | null): string {
-    return (runtimeVersion && synapseCoreVersionMap[runtimeVersion]) || DEFAULT_SYNAPSE_CORE_VERSION;
+    if (!runtimeVersion || compareVersions(runtimeVersion, MIN_RUNTIME_FOR_LATEST_SYNAPSE_CORE) >= 0) {
+        return SYNAPSE_CORE_VERSION_460_AND_ABOVE;
+    }
+    return SYNAPSE_CORE_VERSION_BELOW_460;
 }
 
 const miDownloadUrls: { [key: string]: string } = {


### PR DESCRIPTION
## Description

Ensures the correct version of `org.apache.synapse:synapse-core` is declared and prompt reminders are properly injected when class mediators are created or modified via MI Copilot:
- For MI runtime versions `>= 4.6.0`, the required `synapse-core` dependency version is `4.1.0-wso2v48`.
- For other MI runtime versions (`< 4.6.0`), the required `synapse-core` dependency version is `4.0.0-wso2v165`.

### Changes
1. **`file_tools.ts`**:
   - Added `checkClassMediatorPomStatus` and updated `buildClassMediatorPomReminder` to inspect `pom.xml` packaging (`<packaging>jar</packaging>`) and the presence/version of `org.apache.synapse:synapse-core` against the detected project runtime version.
   - Strips XML comments to prevent commented-out tags/dependencies from masking real configurations.
   - Generates an actionable `<system-reminder>` with the exact XML dependency snippet when packaging or dependency requirements are unmet.
2. **Synapse Context Guides**:
   - Updated `synapse_guide.ts`, `synapse_guide_old.ts`, `copilot/context/synapse_guide.ts`, and `synapse_guide_v1.ts` to specify `<packaging>jar</packaging>` and the runtime-dependent `synapse-core` version requirements.
3. **Unit Tests**:
   - Added unit test suite in `file-tools.class-mediator.test.ts` covering path detection, runtime version resolution, POM inspection, comment stripping, and reminder generation.

Resolves https://github.com/wso2/product-integrator/issues/2048