### PR TITLE
Support Bedrock Application Inference Profiles in Copilot sign-in

### DIFF
--- a/packages/mi-core/src/state-machine-types.ts
+++ b/packages/mi-core/src/state-machine-types.ts
@@ -208,6 +208,91 @@ interface AnthropicKeySecrets {
 
 export type AwsBedrockAuthType = 'iam' | 'api_key';
 
+/** Logical model slots that can be pointed at an Application Inference Profile. */
+export type BedrockInferenceProfileSlot = 'haiku' | 'sonnet' | 'opus';
+
+/**
+ * Optional Bedrock Application Inference Profile ARNs, one per logical model.
+ *
+ * Some organizations attach an SCP/IAM policy that denies direct invocation of
+ * `foundation-model/*` and system-defined `inference-profile/*` resources, and
+ * permits `bedrock:InvokeModel` only against customer-owned, taggable
+ * application inference profiles — the standard cost-allocation / chargeback
+ * pattern. Without an override, both sign-in and every subsequent Copilot
+ * request are denied in such accounts.
+ *
+ * Any slot left unset falls back to the built-in `global.` system profile, so
+ * existing users are unaffected.
+ */
+export type BedrockInferenceProfileOverrides = Partial<Record<BedrockInferenceProfileSlot, string>>;
+
+/** Shape of a Bedrock application inference profile ARN. */
+const BEDROCK_APP_INFERENCE_PROFILE_ARN =
+    /^arn:aws(?:-us-gov|-cn)?:bedrock:[a-z0-9-]+:\d{12}:application-inference-profile\/[A-Za-z0-9._-]+$/;
+
+/** True when `value` looks like a Bedrock application inference profile ARN. */
+export const isBedrockApplicationInferenceProfileArn = (value: string): boolean =>
+    BEDROCK_APP_INFERENCE_PROFILE_ARN.test(value.trim());
+
+/**
+ * Extract the region embedded in an application inference profile ARN, or
+ * undefined when the value is not a well-formed ARN. Used to warn when the ARN
+ * disagrees with the region the user entered.
+ */
+export const getRegionFromInferenceProfileArn = (value: string): string | undefined => {
+    if (!isBedrockApplicationInferenceProfileArn(value)) {
+        return undefined;
+    }
+    return value.trim().split(':')[3];
+};
+
+/** Every override slot, in the order they are presented to the user. */
+export const BEDROCK_INFERENCE_PROFILE_SLOTS: BedrockInferenceProfileSlot[] = ['haiku', 'sonnet', 'opus'];
+
+/**
+ * Slots the default model presets resolve to, so a partial configuration cannot
+ * pass sign-in and then fail on the first request. Sonnet 4.6 is the default
+ * main model and Haiku 4.5 the default sub-agent model; Opus is opt-in, so a
+ * profile for it is only needed if the user selects it in Settings.
+ */
+export const REQUIRED_BEDROCK_INFERENCE_PROFILE_SLOTS: BedrockInferenceProfileSlot[] = ['haiku', 'sonnet'];
+
+/** Trim and drop empty slots so an all-blank advanced form is stored as undefined. */
+export const normalizeInferenceProfileOverrides = (
+    overrides: BedrockInferenceProfileOverrides | undefined
+): BedrockInferenceProfileOverrides | undefined => {
+    if (!overrides) {
+        return undefined;
+    }
+
+    const normalized: BedrockInferenceProfileOverrides = {};
+    let count = 0;
+    for (const slot of BEDROCK_INFERENCE_PROFILE_SLOTS) {
+        const arn = overrides[slot]?.trim();
+        if (arn) {
+            normalized[slot] = arn;
+            count++;
+        }
+    }
+    return count ? normalized : undefined;
+};
+
+/**
+ * Once any Application Inference Profile is configured, the account is one that
+ * forbids the default `global.` profiles — so every slot the default presets use
+ * must be supplied too. Returns the missing slots (empty when nothing is set, or
+ * when the configuration is complete).
+ */
+export const findMissingRequiredInferenceProfiles = (
+    overrides: BedrockInferenceProfileOverrides | undefined
+): BedrockInferenceProfileSlot[] => {
+    const normalized = normalizeInferenceProfileOverrides(overrides);
+    if (!normalized) {
+        return [];
+    }
+    return REQUIRED_BEDROCK_INFERENCE_PROFILE_SLOTS.filter((slot) => !normalized[slot]);
+};
+
 export interface AwsBedrockIamSecrets {
     authType?: 'iam';
     accessKeyId: string;
@@ -216,6 +301,8 @@ export interface AwsBedrockIamSecrets {
     sessionToken?: string;
     /** Optional Tavily API key for web search/fetch on Bedrock (Bedrock has no first-party web tools). */
     tavilyApiKey?: string;
+    /** Optional Application Inference Profile ARNs; see BedrockInferenceProfileOverrides. */
+    inferenceProfiles?: BedrockInferenceProfileOverrides;
 }
 
 export interface AwsBedrockApiKeySecrets {
@@ -224,6 +311,8 @@ export interface AwsBedrockApiKeySecrets {
     region: string;
     /** Optional Tavily API key for web search/fetch on Bedrock (Bedrock has no first-party web tools). */
     tavilyApiKey?: string;
+    /** Optional Application Inference Profile ARNs; see BedrockInferenceProfileOverrides. */
+    inferenceProfiles?: BedrockInferenceProfileOverrides;
 }
 
 export type AwsBedrockSecrets = AwsBedrockIamSecrets | AwsBedrockApiKeySecrets;

--- a/packages/mi-core/src/state-machine-types.ts
+++ b/packages/mi-core/src/state-machine-types.ts
@@ -162,11 +162,13 @@ export type AIMachineEventMap = {
         region: string;
         sessionToken?: string;
         tavilyApiKey?: string;
+        inferenceProfiles?: BedrockInferenceProfileOverrides;
     } | {
         authType: 'api_key';
         apiKey: string;
         region: string;
         tavilyApiKey?: string;
+        inferenceProfiles?: BedrockInferenceProfileOverrides;
     };
     [AI_EVENT_TYPE.SIGN_IN_SUCCESS]: undefined;
     [AI_EVENT_TYPE.LOGOUT]: undefined;
@@ -226,9 +228,15 @@ export type BedrockInferenceProfileSlot = 'haiku' | 'sonnet' | 'opus';
  */
 export type BedrockInferenceProfileOverrides = Partial<Record<BedrockInferenceProfileSlot, string>>;
 
-/** Shape of a Bedrock application inference profile ARN. */
+/**
+ * Shape of a Bedrock application inference profile ARN.
+ *
+ * The partition segment is matched loosely (`aws`, `aws-us-gov`, `aws-cn`,
+ * `aws-iso`, `aws-iso-b`, ...) rather than enumerated, so ARNs from partitions
+ * we do not explicitly know about are not rejected out of hand.
+ */
 const BEDROCK_APP_INFERENCE_PROFILE_ARN =
-    /^arn:aws(?:-us-gov|-cn)?:bedrock:[a-z0-9-]+:\d{12}:application-inference-profile\/[A-Za-z0-9._-]+$/;
+    /^arn:aws(?:-[a-z0-9]+)*:bedrock:[a-z0-9-]+:\d{12}:application-inference-profile\/[A-Za-z0-9._-]+$/;
 
 /** True when `value` looks like a Bedrock application inference profile ARN. */
 export const isBedrockApplicationInferenceProfileArn = (value: string): boolean =>

--- a/packages/mi-extension/src/ai-features/aiMachine.ts
+++ b/packages/mi-extension/src/ai-features/aiMachine.ts
@@ -601,18 +601,18 @@ const validateApiKeyService = async (_context: AIMachineContext, event: any) => 
 };
 
 const validateAwsCredentialsService = async (_context: AIMachineContext, event: any) => {
-    const { authType, accessKeyId, secretAccessKey, region, sessionToken, apiKey, tavilyApiKey } = event.payload || {};
+    const { authType, accessKeyId, secretAccessKey, region, sessionToken, apiKey, tavilyApiKey, inferenceProfiles } = event.payload || {};
     if (authType === 'api_key') {
         if (!apiKey || !region) {
             throw new Error('Amazon Bedrock API key and AWS region are required');
         }
-        return await validateAwsCredentials({ authType, apiKey, region, tavilyApiKey });
+        return await validateAwsCredentials({ authType, apiKey, region, tavilyApiKey, inferenceProfiles });
     }
 
     if (!accessKeyId || !secretAccessKey || !region) {
         throw new Error('AWS access key ID, secret access key, and region are required');
     }
-    return await validateAwsCredentials({ authType: 'iam', accessKeyId, secretAccessKey, region, sessionToken, tavilyApiKey });
+    return await validateAwsCredentials({ authType: 'iam', accessKeyId, secretAccessKey, region, sessionToken, tavilyApiKey, inferenceProfiles });
 };
 
 const getTokenAndLoginMethod = async () => {

--- a/packages/mi-extension/src/ai-features/auth.ts
+++ b/packages/mi-extension/src/ai-features/auth.ts
@@ -28,7 +28,18 @@
  */
 
 import axios from 'axios';
-import { AIUserToken, AuthCredentials, LoginMethod, AwsBedrockSecrets } from '@wso2/mi-core';
+import {
+    AIUserToken,
+    AuthCredentials,
+    LoginMethod,
+    AwsBedrockSecrets,
+    BedrockInferenceProfileOverrides,
+    isBedrockApplicationInferenceProfileArn,
+    getRegionFromInferenceProfileArn,
+    normalizeInferenceProfileOverrides,
+    BEDROCK_INFERENCE_PROFILE_SLOTS,
+    findMissingRequiredInferenceProfiles
+} from '@wso2/mi-core';
 import { extension } from '../MIExtensionContext';
 import * as vscode from 'vscode';
 import { createAnthropic } from '@ai-sdk/anthropic';
@@ -581,9 +592,11 @@ interface AwsBedrockValidationInput {
     apiKey?: string;
     /** Optional Tavily key bundled with Bedrock credentials so users can opt into web tools. */
     tavilyApiKey?: string;
+    /** Optional Application Inference Profile ARNs for accounts that mandate them. */
+    inferenceProfiles?: BedrockInferenceProfileOverrides;
 }
 
-const validateBedrockRegion = (region: string): void => {
+const validateBedrockRegion = (region: string, hasExplicitInferenceProfiles = false): void => {
     if (!region) {
         throw new Error('AWS region is required.');
     }
@@ -596,7 +609,11 @@ const validateBedrockRegion = (region: string): void => {
     // / getBedrockRegionalPrefix in connection.ts) is only published in the
     // commercial AWS partition. GovCloud (`us-gov-*`) and China (`cn-*`) regions
     // would silently fail at runtime with "model not found", so reject up front.
-    if (region.startsWith('us-gov-') || region.startsWith('cn-')) {
+    //
+    // This only constrains the built-in default. When the caller supplies explicit
+    // Application Inference Profile ARNs the `global.` profile is never used, so
+    // the partition restriction no longer applies and the guard is skipped.
+    if (!hasExplicitInferenceProfiles && (region.startsWith('us-gov-') || region.startsWith('cn-'))) {
         throw new Error(
             `AWS region "${region}" is not supported. The Anthropic models on Bedrock ` +
             `(Haiku 4.5, Sonnet 4.6, Opus 4.8) are only available via the global. ` +
@@ -606,9 +623,89 @@ const validateBedrockRegion = (region: string): void => {
     }
 };
 
-const getBedrockValidationModelId = async (region: string): Promise<string> => {
+const getBedrockValidationModelId = async (
+    region: string,
+    overrides?: BedrockInferenceProfileOverrides
+): Promise<string> => {
     const { getBedrockValidationModelId: resolveValidationModelId } = await import('./connection');
-    return resolveValidationModelId(region);
+    return resolveValidationModelId(region, overrides);
+};
+
+/**
+ * Reject malformed Application Inference Profile ARNs before we spend a Bedrock
+ * call on them, and warn when an ARN's region disagrees with the chosen region
+ * (Bedrock resolves the profile in its own region, which silently bills and
+ * routes elsewhere).
+ */
+const validateInferenceProfileOverrides = (
+    overrides: BedrockInferenceProfileOverrides | undefined,
+    region: string
+): void => {
+    if (!overrides) {
+        return;
+    }
+
+    const missing = findMissingRequiredInferenceProfiles(overrides);
+    if (missing.length) {
+        throw new Error(
+            `An Application Inference Profile ARN is also required for: ${missing.join(', ')}. ` +
+            `Accounts that mandate application profiles cannot use the default profiles for the ` +
+            `remaining models, so Copilot would fail on its first request.`
+        );
+    }
+
+    for (const slot of BEDROCK_INFERENCE_PROFILE_SLOTS) {
+        const arn = overrides[slot];
+        if (!arn) {
+            continue;
+        }
+        if (!isBedrockApplicationInferenceProfileArn(arn)) {
+            throw new Error(
+                `The ${slot} inference profile is not a valid Application Inference Profile ARN. ` +
+                `Expected the form arn:aws:bedrock:<region>:<account-id>:application-inference-profile/<id>.`
+            );
+        }
+        const arnRegion = getRegionFromInferenceProfileArn(arn);
+        if (arnRegion && arnRegion !== region) {
+            logWarn(
+                `Bedrock ${slot} inference profile is in ${arnRegion} but the configured region is ${region}. ` +
+                `Requests will be served from ${arnRegion}.`
+            );
+        }
+    }
+};
+
+/**
+ * Turn a Bedrock authorization failure into a message that names the actual
+ * cause. A denial on a `foundation-model` or system `inference-profile` resource
+ * means the account's policy forbids that route — typically because it requires
+ * Application Inference Profiles — not that the credentials are wrong.
+ */
+const describeBedrockValidationFailure = (
+    detail: string,
+    hasExplicitInferenceProfiles: boolean
+): string => {
+    const isAuthorizationFailure = /AccessDenied|not authorized|explicit deny/i.test(detail);
+    const mentionsUnroutableResource = /foundation-model|inference-profile/i.test(detail);
+
+    if (isAuthorizationFailure && mentionsUnroutableResource && !hasExplicitInferenceProfiles) {
+        return (
+            'Your credentials are valid, but this AWS account does not allow invoking the model directly. ' +
+            'Accounts that require Amazon Bedrock Application Inference Profiles must supply the profile ARNs ' +
+            'under "Advanced: Application Inference Profiles" on this form. ' +
+            `(${detail})`
+        );
+    }
+
+    if (isAuthorizationFailure && hasExplicitInferenceProfiles) {
+        return (
+            'Your credentials are valid, but the supplied Application Inference Profile could not be invoked. ' +
+            'Check that the ARN is correct, is in the selected region, and that this principal is allowed to ' +
+            `invoke it. (${detail})`
+        );
+    }
+
+    return `Validation failed. Please check your AWS Bedrock authentication details and model access. (${detail})`;
 };
 
 /**
@@ -618,8 +715,11 @@ export const validateAwsCredentials = async (credentials: AwsBedrockValidationIn
     const authType = credentials.authType === 'api_key' ? 'api_key' : 'iam';
     const region = credentials.region?.trim() ?? '';
     const tavilyApiKey = credentials.tavilyApiKey?.trim() || undefined;
+    const inferenceProfiles = normalizeInferenceProfileOverrides(credentials.inferenceProfiles);
+    const hasExplicitInferenceProfiles = Boolean(inferenceProfiles);
 
-    validateBedrockRegion(region);
+    validateBedrockRegion(region, hasExplicitInferenceProfiles);
+    validateInferenceProfileOverrides(inferenceProfiles, region);
 
     try {
         logInfo(`Validating AWS Bedrock ${authType === 'api_key' ? 'API key' : 'IAM credentials'}...`);
@@ -634,7 +734,7 @@ export const validateAwsCredentials = async (credentials: AwsBedrockValidationIn
                 region,
                 apiKey,
             });
-            const bedrockClient = bedrock(await getBedrockValidationModelId(region));
+            const bedrockClient = bedrock(await getBedrockValidationModelId(region, inferenceProfiles));
 
             await generateText({
                 model: bedrockClient,
@@ -649,6 +749,7 @@ export const validateAwsCredentials = async (credentials: AwsBedrockValidationIn
                     apiKey,
                     region,
                     tavilyApiKey,
+                    inferenceProfiles,
                 }
             };
             await storeAuthCredentials(authCredentials);
@@ -679,7 +780,7 @@ export const validateAwsCredentials = async (credentials: AwsBedrockValidationIn
             secretAccessKey,
             sessionToken,
         });
-        const bedrockClient = bedrock(await getBedrockValidationModelId(region));
+        const bedrockClient = bedrock(await getBedrockValidationModelId(region, inferenceProfiles));
 
         await generateText({
             model: bedrockClient,
@@ -696,6 +797,7 @@ export const validateAwsCredentials = async (credentials: AwsBedrockValidationIn
                 region,
                 sessionToken,
                 tavilyApiKey,
+                inferenceProfiles,
             }
         };
         await storeAuthCredentials(authCredentials);
@@ -706,7 +808,7 @@ export const validateAwsCredentials = async (credentials: AwsBedrockValidationIn
     } catch (error) {
         logError('AWS Bedrock credential validation failed', error);
         const detail = error instanceof Error ? error.message : String(error);
-        throw new Error(`Validation failed. Please check your AWS Bedrock authentication details and model access. (${detail})`);
+        throw new Error(describeBedrockValidationFailure(detail, hasExplicitInferenceProfiles));
     }
 };
 

--- a/packages/mi-extension/src/ai-features/connection.ts
+++ b/packages/mi-extension/src/ai-features/connection.ts
@@ -398,15 +398,20 @@ export const getAnthropicClient = async (model: AnthropicModel): Promise<any> =>
 export const getAnthropicClientForCustomModel = async (modelId: string): Promise<any> => {
     const loginMethod = await getLoginMethod();
     if (loginMethod === LoginMethod.AWS_BEDROCK) {
-        if (!isBedrockApplicationInferenceProfileArn(modelId)) {
+        // Trim before validating AND before handing the value to the provider:
+        // the Bedrock provider URL-encodes the model reference into the request
+        // path verbatim, so surrounding whitespace would become %20 and produce
+        // a request for a profile that does not exist.
+        const profileArn = modelId.trim();
+        if (!isBedrockApplicationInferenceProfileArn(profileArn)) {
             throw new Error(
                 'Custom model IDs are not supported with AWS Bedrock. Use a standard model preset, ' +
                 'or supply an Application Inference Profile ARN.'
             );
         }
         const { provider: bedrockProvider } = await getBedrockProvider();
-        logDebug(`Using Bedrock application inference profile: ${modelId}`);
-        return bedrockProvider(modelId);
+        logDebug(`Using Bedrock application inference profile: ${profileArn}`);
+        return bedrockProvider(profileArn);
     }
     const provider = await getAnthropicProvider();
     return provider(modelId);

--- a/packages/mi-extension/src/ai-features/connection.ts
+++ b/packages/mi-extension/src/ai-features/connection.ts
@@ -26,7 +26,13 @@ import {
     isStsTokenUnavailableError
 } from "./auth";
 import { StateMachineAI, openAIWebview } from "./aiMachine";
-import { AI_EVENT_TYPE, LoginMethod } from "@wso2/mi-core";
+import {
+    AI_EVENT_TYPE,
+    LoginMethod,
+    BedrockInferenceProfileOverrides,
+    BedrockInferenceProfileSlot,
+    isBedrockApplicationInferenceProfileArn
+} from "@wso2/mi-core";
 import { logInfo, logDebug, logError } from "./copilot/logger";
 
 export const ANTHROPIC_HAIKU_4_5 = "claude-haiku-4-5";
@@ -63,14 +69,48 @@ const BEDROCK_INFERENCE_PROFILE_PREFIX = 'global';
 
 export const getBedrockRegionalPrefix = (_region: string): string => BEDROCK_INFERENCE_PROFILE_PREFIX;
 
-/**
- * Resolve the Bedrock inference-profile ID used to validate AWS credentials.
- * Uses Haiku 4.5 — cheapest of the three.
- */
-export const getBedrockValidationModelId = (region: string): string => {
-    const regionalPrefix = getBedrockRegionalPrefix(region);
-    return `${regionalPrefix}.${BEDROCK_MODEL_MAP[ANTHROPIC_HAIKU_4_5]}`;
+/** Maps each supported model onto the override slot users configure at sign-in. */
+const BEDROCK_PROFILE_SLOT: Record<string, BedrockInferenceProfileSlot> = {
+    [ANTHROPIC_HAIKU_4_5]: 'haiku',
+    [ANTHROPIC_SONNET_4_6]: 'sonnet',
+    [ANTHROPIC_OPUS_4_8]: 'opus',
 };
+
+/**
+ * Resolve the Bedrock model reference for `model`.
+ *
+ * When the account supplies an Application Inference Profile ARN for this
+ * model, that ARN is returned verbatim — accounts whose policy permits
+ * `bedrock:InvokeModel` only through application profiles cannot invoke the
+ * `global.` system profile at all. Otherwise we fall back to the system
+ * profile, which is what every account without such a policy uses.
+ */
+export const resolveBedrockModelReference = (
+    model: AnthropicModel,
+    region: string,
+    overrides?: BedrockInferenceProfileOverrides
+): string => {
+    const slot = BEDROCK_PROFILE_SLOT[model];
+    const override = slot ? overrides?.[slot]?.trim() : undefined;
+    if (override) {
+        return override;
+    }
+
+    const bedrockModelId = BEDROCK_MODEL_MAP[model];
+    if (!bedrockModelId) {
+        throw new Error(`No Bedrock model mapping found for: ${model}`);
+    }
+    return `${getBedrockRegionalPrefix(region)}.${bedrockModelId}`;
+};
+
+/**
+ * Resolve the Bedrock model reference used to validate AWS credentials.
+ * Uses Haiku 4.5 — cheapest of the three — honouring an override when set.
+ */
+export const getBedrockValidationModelId = (
+    region: string,
+    overrides?: BedrockInferenceProfileOverrides
+): string => resolveBedrockModelReference(ANTHROPIC_HAIKU_4_5, region, overrides);
 
 let cachedAnthropic: ReturnType<typeof createAnthropic> | null = null;
 let cachedAuthMethod: LoginMethod | null = null;
@@ -338,12 +378,7 @@ export const getAnthropicClient = async (model: AnthropicModel): Promise<any> =>
 
     if (loginMethod === LoginMethod.AWS_BEDROCK) {
         const { provider: bedrockProvider, credentials } = await getBedrockProvider();
-        const regionalPrefix = getBedrockRegionalPrefix(credentials.region);
-        const bedrockModelId = BEDROCK_MODEL_MAP[model];
-        if (!bedrockModelId) {
-            throw new Error(`No Bedrock model mapping found for: ${model}`);
-        }
-        const fullModelId = `${regionalPrefix}.${bedrockModelId}`;
+        const fullModelId = resolveBedrockModelReference(model, credentials.region, credentials.inferenceProfiles);
         logDebug(`Using Bedrock model: ${fullModelId}`);
         return bedrockProvider(fullModelId);
     }
@@ -354,12 +389,24 @@ export const getAnthropicClient = async (model: AnthropicModel): Promise<any> =>
 
 /**
  * Get an Anthropic client for an arbitrary (custom) model ID string.
- * Custom model IDs are NOT supported with AWS Bedrock — throws immediately.
+ *
+ * On AWS Bedrock only one form of custom reference is meaningful: an
+ * Application Inference Profile ARN, which the Bedrock provider passes straight
+ * through (it URL-encodes the model reference into the request path). Plain
+ * Anthropic model slugs still have no Bedrock equivalent and are rejected.
  */
 export const getAnthropicClientForCustomModel = async (modelId: string): Promise<any> => {
     const loginMethod = await getLoginMethod();
     if (loginMethod === LoginMethod.AWS_BEDROCK) {
-        throw new Error('Custom model IDs are not supported with AWS Bedrock. Use a standard model preset instead.');
+        if (!isBedrockApplicationInferenceProfileArn(modelId)) {
+            throw new Error(
+                'Custom model IDs are not supported with AWS Bedrock. Use a standard model preset, ' +
+                'or supply an Application Inference Profile ARN.'
+            );
+        }
+        const { provider: bedrockProvider } = await getBedrockProvider();
+        logDebug(`Using Bedrock application inference profile: ${modelId}`);
+        return bedrockProvider(modelId);
     }
     const provider = await getAnthropicProvider();
     return provider(modelId);

--- a/packages/mi-visualizer/src/views/AIPanel/component/WaitingForLoginSection.tsx
+++ b/packages/mi-visualizer/src/views/AIPanel/component/WaitingForLoginSection.tsx
@@ -17,7 +17,16 @@
  */
 
 import styled from "@emotion/styled";
-import { AI_EVENT_TYPE, LoginMethod } from "@wso2/mi-core";
+import {
+    AI_EVENT_TYPE,
+    LoginMethod,
+    BedrockInferenceProfileSlot,
+    isBedrockApplicationInferenceProfileArn,
+    getRegionFromInferenceProfileArn,
+    normalizeInferenceProfileOverrides,
+    BEDROCK_INFERENCE_PROFILE_SLOTS,
+    findMissingRequiredInferenceProfiles
+} from "@wso2/mi-core";
 import { useVisualizerContext } from "@wso2/mi-rpc-client";
 import { useState } from "react";
 import { Codicon } from "@wso2/ui-toolkit";
@@ -27,12 +36,25 @@ import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 const MIN_ANTHROPIC_API_KEY_LENGTH = 20;
 type BedrockAuthType = "api_key" | "iam";
 
+/** Display names for the Application Inference Profile slots. */
+const INFERENCE_PROFILE_LABELS: Record<BedrockInferenceProfileSlot, string> = {
+    haiku: "Haiku 4.5",
+    sonnet: "Sonnet 4.6",
+    opus: "Opus 4.8",
+};
+
+// The parent chain is height:100%, so without an explicit height + overflow the
+// content is clipped rather than scrolled — the Connect button becomes
+// unreachable on short panels (and for any form long enough to overflow).
 const Container = styled.div`
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     padding: 10px;
     gap: 8px;
+    height: 100%;
+    box-sizing: border-box;
+    overflow-y: auto;
 `;
 
 // AlertBox-style container for consistency
@@ -256,6 +278,16 @@ export const WaitingForLoginSection = ({ loginMethod, isValidating = false, erro
     const [showAwsSecretKey, setShowAwsSecretKey] = useState(false);
     const [showAwsAccessKey, setShowAwsAccessKey] = useState(false);
     const [showAwsSessionToken, setShowAwsSessionToken] = useState(false);
+    // Application Inference Profile ARNs. Only needed by accounts whose policy
+    // denies direct foundation-model / system inference-profile invocation and
+    // requires routing through customer-owned, taggable application profiles.
+    // Collapsed by default so the common case stays a three-field form.
+    const [showInferenceProfiles, setShowInferenceProfiles] = useState(false);
+    const [inferenceProfiles, setInferenceProfiles] = useState<Record<BedrockInferenceProfileSlot, string>>({
+        haiku: "",
+        sonnet: "",
+        opus: ""
+    });
 
     const cancelLogin = () => {
         rpcClient.sendAIStateEvent(AI_EVENT_TYPE.CANCEL_LOGIN);
@@ -320,6 +352,58 @@ export const WaitingForLoginSection = ({ loginMethod, isValidating = false, erro
         }
     };
 
+    const handleInferenceProfileChange = (slot: BedrockInferenceProfileSlot) => (e: any) => {
+        const value = e.target?.value ?? '';
+        setInferenceProfiles(prev => ({ ...prev, [slot]: value }));
+        if (clientError) {
+            setClientError("");
+        }
+    };
+
+    /**
+     * Validate the optional profile ARNs and return them ready for the payload.
+     * Returns `false` when something is malformed, having already surfaced the error.
+     */
+    const collectInferenceProfiles = (region: string) => {
+        const normalized = normalizeInferenceProfileOverrides(inferenceProfiles);
+        if (!normalized) {
+            return undefined;
+        }
+
+        const missing = findMissingRequiredInferenceProfiles(normalized);
+        if (missing.length) {
+            setClientError(
+                `Also enter a profile ARN for ${missing.map((slot) => INFERENCE_PROFILE_LABELS[slot]).join(" and ")}. ` +
+                `These are the default models, so Copilot would fail on its first request without them.`
+            );
+            return false as const;
+        }
+
+        for (const slot of BEDROCK_INFERENCE_PROFILE_SLOTS) {
+            const arn = normalized[slot];
+            if (!arn) {
+                continue;
+            }
+            if (!isBedrockApplicationInferenceProfileArn(arn)) {
+                setClientError(
+                    `The ${slot} inference profile must be an Application Inference Profile ARN ` +
+                    `(arn:aws:bedrock:<region>:<account-id>:application-inference-profile/<id>).`
+                );
+                return false as const;
+            }
+            const arnRegion = getRegionFromInferenceProfileArn(arn);
+            if (arnRegion && arnRegion !== region) {
+                setClientError(
+                    `The ${slot} inference profile is in ${arnRegion}, but the region above is ${region}. ` +
+                    `Use profiles from the same region.`
+                );
+                return false as const;
+            }
+        }
+
+        return normalized;
+    };
+
     const connectWithAwsBedrock = () => {
         setClientError("");
         const { accessKeyId, secretAccessKey, region, sessionToken } = awsCredentials;
@@ -330,6 +414,12 @@ export const WaitingForLoginSection = ({ loginMethod, isValidating = false, erro
         }
 
         const trimmedTavilyKey = tavilyApiKey.trim() || undefined;
+
+        const collectedProfiles = collectInferenceProfiles(region.trim());
+        if (collectedProfiles === false) {
+            setShowInferenceProfiles(true);
+            return;
+        }
 
         if (bedrockAuthType === "api_key") {
             if (!bedrockApiKey.trim()) {
@@ -344,6 +434,7 @@ export const WaitingForLoginSection = ({ loginMethod, isValidating = false, erro
                     apiKey: bedrockApiKey.trim(),
                     region: region.trim(),
                     tavilyApiKey: trimmedTavilyKey,
+                    inferenceProfiles: collectedProfiles,
                 },
             } as any);
             return;
@@ -367,6 +458,7 @@ export const WaitingForLoginSection = ({ loginMethod, isValidating = false, erro
                 region: region.trim(),
                 sessionToken: sessionToken.trim() || undefined,
                 tavilyApiKey: trimmedTavilyKey,
+                inferenceProfiles: collectedProfiles,
             },
         } as any);
     };
@@ -579,6 +671,61 @@ export const WaitingForLoginSection = ({ loginMethod, isValidating = false, erro
                         </>
                     )}
 
+                    {/* Optional Application Inference Profile ARNs. Accounts whose SCP/IAM
+                        policy permits bedrock:InvokeModel only through customer-owned
+                        application profiles cannot use the built-in `global.` system profile
+                        at all, so without these fields sign-in is impossible for them. */}
+                    <HelperText>
+                        <button
+                            type="button"
+                            onClick={() => setShowInferenceProfiles(!showInferenceProfiles)}
+                            style={{
+                                color: "var(--vscode-textLink-foreground)",
+                                background: "transparent",
+                                border: "none",
+                                padding: 0,
+                                cursor: "pointer",
+                                font: "inherit",
+                                display: "inline-flex",
+                                alignItems: "center",
+                                gap: "4px",
+                            }}
+                            aria-expanded={showInferenceProfiles}
+                            {...(isValidating ? { disabled: true } : {})}
+                        >
+                            <Codicon name={showInferenceProfiles ? "chevron-down" : "chevron-right"} />
+                            Advanced: Application Inference Profiles
+                        </button>
+                    </HelperText>
+
+                    {showInferenceProfiles && (
+                        <>
+                            <HelperText>
+                                Only needed if your AWS account requires all Bedrock traffic to be routed
+                                through Application Inference Profiles (commonly enforced for cost allocation).
+                                Leave blank to use the default cross-region system profiles.
+                            </HelperText>
+                            {BEDROCK_INFERENCE_PROFILE_SLOTS.map((slot) => (
+                                <InputContainer key={slot}>
+                                    <InputRow>
+                                        <StyledTextField
+                                            type="text"
+                                            placeholder={`${INFERENCE_PROFILE_LABELS[slot]} profile ARN (optional)`}
+                                            value={inferenceProfiles[slot]}
+                                            onChange={handleInferenceProfileChange(slot)}
+                                            {...(isValidating ? { disabled: true } : {})}
+                                        />
+                                    </InputRow>
+                                </InputContainer>
+                            ))}
+                            <HelperText>
+                                Haiku 4.5 and Sonnet 4.6 are the default models and are both required once
+                                you use profiles. Opus 4.8 is optional — set it only if you select Opus in
+                                Settings, otherwise requests using it will be rejected.
+                            </HelperText>
+                        </>
+                    )}
+
                     {/* Optional Tavily key — Bedrock has no first-party web tools, so without
                         this key the agent can't run web_search / web_fetch. Skippable; can be
                         added later in Settings. */}
@@ -654,7 +801,7 @@ export const WaitingForLoginSection = ({ loginMethod, isValidating = false, erro
                         <VSCodeButton
                             appearance="primary"
                             onClick={connectWithAwsBedrock}
-                            {...(isValidating || !isFormValid ? { disabled: true } : {})}
+                            disabled={isValidating || !isFormValid}
                         >
                             {isValidating ? "Validating..." : "Connect to AWS Bedrock"}
                         </VSCodeButton>

--- a/packages/mi-visualizer/src/views/AIPanel/component/WaitingForLoginSection.tsx
+++ b/packages/mi-visualizer/src/views/AIPanel/component/WaitingForLoginSection.tsx
@@ -19,6 +19,7 @@
 import styled from "@emotion/styled";
 import {
     AI_EVENT_TYPE,
+    AIMachineEventMap,
     LoginMethod,
     BedrockInferenceProfileSlot,
     isBedrockApplicationInferenceProfileArn,
@@ -427,15 +428,16 @@ export const WaitingForLoginSection = ({ loginMethod, isValidating = false, erro
                 return;
             }
 
+            const apiKeyPayload: AIMachineEventMap[AI_EVENT_TYPE.SUBMIT_AWS_CREDENTIALS] = {
+                authType: "api_key",
+                apiKey: bedrockApiKey.trim(),
+                region: region.trim(),
+                tavilyApiKey: trimmedTavilyKey,
+                inferenceProfiles: collectedProfiles,
+            };
             rpcClient.sendAIStateEvent({
                 type: AI_EVENT_TYPE.SUBMIT_AWS_CREDENTIALS,
-                payload: {
-                    authType: "api_key",
-                    apiKey: bedrockApiKey.trim(),
-                    region: region.trim(),
-                    tavilyApiKey: trimmedTavilyKey,
-                    inferenceProfiles: collectedProfiles,
-                },
+                payload: apiKeyPayload,
             } as any);
             return;
         }
@@ -449,17 +451,18 @@ export const WaitingForLoginSection = ({ loginMethod, isValidating = false, erro
             return;
         }
 
+        const iamPayload: AIMachineEventMap[AI_EVENT_TYPE.SUBMIT_AWS_CREDENTIALS] = {
+            authType: "iam",
+            accessKeyId: accessKeyId.trim(),
+            secretAccessKey: secretAccessKey.trim(),
+            region: region.trim(),
+            sessionToken: sessionToken.trim() || undefined,
+            tavilyApiKey: trimmedTavilyKey,
+            inferenceProfiles: collectedProfiles,
+        };
         rpcClient.sendAIStateEvent({
             type: AI_EVENT_TYPE.SUBMIT_AWS_CREDENTIALS,
-            payload: {
-                authType: "iam",
-                accessKeyId: accessKeyId.trim(),
-                secretAccessKey: secretAccessKey.trim(),
-                region: region.trim(),
-                sessionToken: sessionToken.trim() || undefined,
-                tavilyApiKey: trimmedTavilyKey,
-                inferenceProfiles: collectedProfiles,
-            },
+            payload: iamPayload,
         } as any);
     };
     


### PR DESCRIPTION
Fixes: https://github.com/wso2/mi-vscode/issues/1579

## Issue

Bedrock sign-in ("IAM credentials" and "Bedrock API key") validated credentials by
invoking a hardcoded model reference — `global.anthropic.claude-haiku-4-5-20251001-v1:0`,
built by `getBedrockValidationModelId()` — with no way to override it from either form.

Some organizations enforce a policy that denies direct `foundation-model/*` and
system `inference-profile/*` invocation, permitting `bedrock:InvokeModel` only through
customer-owned Application Inference Profiles (a common cost-allocation pattern).
In those accounts the validation call is denied and sign-in is impossible, even
though the credentials are valid.

The same model reference is also constructed on every runtime request in
`getAnthropicClient()`, so this affected all Copilot traffic, not just login. The
one escape hatch, `getAnthropicClientForCustomModel()`, rejected Bedrock outright.

The failure surfaced as *"Please check your AWS Bedrock authentication details and
model access"*, pointing users at the one thing that wasn't wrong.

## Fix

- Optional per-model Application Inference Profile ARNs, persisted with the Bedrock credentials
- Collapsed **Advanced: Application Inference Profiles** section in both sign-in forms, with ARN and region-mismatch validation shared between webview and extension
- `getBedrockValidationModelId()` and `getAnthropicClient()` both resolve through the override, falling back to today's `global.` profile when unset
- `getAnthropicClientForCustomModel()` accepts a profile ARN on Bedrock
- Haiku and Sonnet are required once any profile is set (they're the default presets), so login can't succeed and then fail on the first request; Opus stays optional
- Authorization failures now name the actual cause instead of blaming credentials
- The GovCloud/China region guard is skipped when explicit ARNs are supplied, since it only existed to protect the `global.` default

Also fixes a pre-existing layout bug: `html`/`body`/`#root` are `overflow: hidden`
and the login `Container` had no height, so longer forms clipped the Connect button
instead of scrolling. Affected the Anthropic API key form too.

## Testing

Reproduced against a real AWS account with an IAM policy simulating the SCP.
With the same assumed-role credentials: the hardcoded reference returns
`AccessDeniedException`, an application profile ARN succeeds. Verified in the
extension UI — sign-in and chat both work with profile ARNs configured, and an
unrestricted account is unaffected.

No SDK changes needed: `@ai-sdk/amazon-bedrock` already URL-encodes the model
reference into the request path, so an ARN passes through unmodified.