### PR TITLE
Update MI Copilot's fallback HTTP and AI connector versions to 1.0.0/1.0.1

### DIFF
--- a/packages/mi-extension/src/ai-features/agent-mode/context/connectors/connector_db.ts
+++ b/packages/mi-extension/src/ai-features/agent-mode/context/connectors/connector_db.ts
@@ -26,8 +26,8 @@ export const CONNECTOR_DB = [
         "mavenArtifactId": "mi-connector-ai",
         "id": "",
         "version": {
-            "tagName": "0.1.8",
-            "releaseId": "236147369",
+            "tagName": "1.0.1",
+            "releaseId": "380231497",
             "isLatest": true,
             "isDeprecated": false,
             "operations": [
@@ -19391,8 +19391,8 @@ export const CONNECTOR_DB = [
         "mavenArtifactId": "mi-connector-http",
         "id": "",
         "version": {
-            "tagName": "0.1.14",
-            "releaseId": "255665655",
+            "tagName": "1.0.0",
+            "releaseId": "366757742",
             "isLatest": true,
             "isDeprecated": false,
             "operations": [


### PR DESCRIPTION
### Purpose

Fixes https://github.com/wso2/product-integrator/issues/2124

MI Copilot's agent-mode connector catalog (`CONNECTOR_DB`) is used as the last-resort fallback when the live connector store API and its cache are unavailable (`connector_store_cache.ts`). It still pinned:

- `mi-connector-http` at `0.1.14`
- `mi-connector-ai` at `0.1.8`

Both connectors have since reached GA:

- `mi-connector-http` → `1.0.0`
- `mi-connector-ai` → `1.0.1`

This fallback version also seeds which version `get_connector_info`/`manage_connector` resolve to (via `resolveTargetVersion(..., 'pom-or-latest')`) before asking the language server for the real descriptor, so a stale fallback version means Copilot asks the LS to fetch/generate against an outdated connector release when the live store isn't reachable.

### Changes

- Bumped `tagName`/`releaseId` for `mi-connector-http` (`0.1.14` → `1.0.0`) and `mi-connector-ai` (`0.1.8` → `1.0.1`) in `packages/mi-extension/src/ai-features/agent-mode/context/connectors/connector_db.ts`, matching the released versions on Maven Central and each connector's GitHub release.
- No operation/parameter schema changes were needed — both releases' changelogs show only descriptor/property housekeeping ahead of GA, no breaking operation changes.